### PR TITLE
Document the SonarCloud CI-analysis gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,12 @@ coverage.
   handled like a lint error — the code adapts, or the divergence is
   settled as a documented verdict (e.g. the `Number.NaN` convention in
   `eslint.config.ts`) — never merged over.
+- The SonarCloud project runs **CI-based analysis** (the `ci.yml` scan
+  step on the `lts/*` leg): **Automatic Analysis must stay DISABLED** in
+  the project's Administration settings, or the CI scanner aborts with
+  `exit 3` and fails the required `Test (Node lts/*)` leg. Coverage
+  exclusions cover `settings/**` and `scripts/**` (the webview bundle is
+  browser code exercised on-device, not in vitest).
 - Verify claimed library behavior empirically (headless chromium against
   the real dist/bundle in the scratchpad) rather than from memory.
 - Homey App Store releases: write the user-facing changelog entry into


### PR DESCRIPTION
Small doc-only follow-up to the 23.0.0 rewrite: records in CLAUDE.md that the SonarCloud project must keep Automatic Analysis disabled (so the ci.yml scan owns the analysis, else the scanner aborts the required lts leg), and notes the settings/scripts coverage exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)