### PR TITLE
Align the settings page structure and labels on melcloud

### DIFF
--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -12,7 +12,7 @@
       "failure": "Authentication failed.",
       "legend": "Credentials",
       "rejected": "Heatzy rejected your credentials — please check them and sign in again.",
-      "reset": "Log out",
+      "reset": "Reset",
       "resetConfirm": "This immediately signs you out and clears your saved Heatzy credentials."
     },
     "boolean": {
@@ -21,14 +21,14 @@
     },
     "devices": {
       "apply": {
-        "button": "Apply to all devices",
         "nothing": "No change to apply."
       },
-      "legend": "Device settings"
+      "legend": "All device settings"
     },
     "loadFailed": "The settings page failed to load. Please try again.",
     "refresh": "Refresh",
     "success": "Update succeeded.",
-    "title": "Heatzy settings"
+    "title": "Heatzy settings",
+    "update": "Update"
   }
 }

--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -12,7 +12,7 @@
       "failure": "L'authentification a échoué.",
       "legend": "Identifiants",
       "rejected": "Heatzy a refusé vos identifiants — vérifiez-les puis reconnectez-vous.",
-      "reset": "Se déconnecter",
+      "reset": "Réinitialiser",
       "resetConfirm": "Cela vous déconnecte immédiatement et efface vos identifiants Heatzy enregistrés."
     },
     "boolean": {
@@ -21,14 +21,14 @@
     },
     "devices": {
       "apply": {
-        "button": "Appliquer à tous les appareils",
         "nothing": "Aucun changement à appliquer."
       },
-      "legend": "Paramètres des appareils"
+      "legend": "Paramètres de tous les appareils"
     },
     "loadFailed": "La page de réglages n'a pas pu se charger. Veuillez réessayer.",
     "refresh": "Rafraîchir",
     "success": "La mise à jour a réussi.",
-    "title": "Paramètres Heatzy"
+    "title": "Paramètres Heatzy",
+    "update": "Mettre à jour"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,7 +8,7 @@
       "failure": "Authentication failed.",
       "legend": "Credentials",
       "rejected": "Heatzy rejected your credentials — please check them and sign in again.",
-      "reset": "Log out",
+      "reset": "Reset",
       "resetConfirm": "This immediately signs you out and clears your saved Heatzy credentials."
     },
     "boolean": {
@@ -20,12 +20,13 @@
         "button": "Apply to all devices",
         "nothing": "No change to apply."
       },
-      "legend": "Device settings"
+      "legend": "All device settings"
     },
     "refresh": "Refresh",
     "success": "Update succeeded.",
     "title": "Heatzy settings",
-    "loadFailed": "The settings page failed to load. Please try again."
+    "loadFailed": "The settings page failed to load. Please try again.",
+    "update": "Update"
   },
   "notifications": {
     "sessionExpired": "Your Heatzy session has expired: please sign in again from the app settings.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -8,7 +8,7 @@
       "failure": "L'authentification a échoué.",
       "legend": "Identifiants",
       "rejected": "Heatzy a refusé vos identifiants — vérifiez-les puis reconnectez-vous.",
-      "reset": "Se déconnecter",
+      "reset": "Réinitialiser",
       "resetConfirm": "Cela vous déconnecte immédiatement et efface vos identifiants Heatzy enregistrés."
     },
     "boolean": {
@@ -20,12 +20,13 @@
         "button": "Appliquer à tous les appareils",
         "nothing": "Aucun changement à appliquer."
       },
-      "legend": "Paramètres des appareils"
+      "legend": "Paramètres de tous les appareils"
     },
     "refresh": "Rafraîchir",
     "success": "La mise à jour a réussi.",
     "title": "Paramètres Heatzy",
-    "loadFailed": "La page de réglages n'a pas pu se charger. Veuillez réessayer."
+    "loadFailed": "La page de réglages n'a pas pu se charger. Veuillez réessayer.",
+    "update": "Mettre à jour"
   },
   "notifications": {
     "sessionExpired": "Votre session Heatzy a expiré : reconnectez-vous depuis les réglages de l’application.",

--- a/settings/index.html
+++ b/settings/index.html
@@ -63,31 +63,36 @@
                     type="button"
                     class="homey-button-primary-full"
                     data-i18n="settings.authenticate.reset"
-                >Log out</button>
+                >Reset</button>
                 <button
                     id="authenticate"
                     type="button"
                     class="homey-button-primary-full"
                     data-i18n="settings.authenticate.button"
-                >Authenticate</button>
+                >Log in</button>
             </div>
         </details>
-        <fieldset id="devices" class="homey-form-fieldset">
-            <legend class="homey-form-legend" data-i18n="settings.devices.legend">Device settings</legend>
+        <!-- Shown once authenticated — hidden by default to prevent a flash. -->
+        <fieldset
+            id="devices"
+            class="homey-form-fieldset"
+            hidden
+        >
+            <legend class="homey-form-legend" data-i18n="settings.devices.legend">All device settings</legend>
             <div id="settings_common"></div>
             <div class="homey-form-group container">
                 <button
                     id="refresh_settings_common"
                     type="button"
-                    class="homey-button-secondary-shadow-full"
+                    class="homey-button-secondary-shadow"
                     data-i18n="settings.refresh"
                 >Refresh</button>
                 <button
                     id="apply_settings_common"
                     type="button"
-                    class="homey-button-danger-shadow-full"
-                    data-i18n="settings.devices.apply.button"
-                >Apply</button>
+                    class="homey-button-danger-shadow"
+                    data-i18n="settings.update"
+                >Update</button>
             </div>
         </fieldset>
     </body>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -27,6 +27,7 @@ interface PageElements {
   readonly applySettings: HTMLButtonElement
   readonly authenticate: HTMLButtonElement
   readonly authentication: HTMLDetailsElement
+  readonly devices: HTMLFieldSetElement
   readonly login: HTMLDivElement
   readonly refreshSettings: HTMLButtonElement
   readonly resetCredentials: HTMLButtonElement
@@ -71,6 +72,7 @@ const getPageElements = (): PageElements => ({
   applySettings: getElement('apply_settings_common', HTMLButtonElement),
   authenticate: getElement('authenticate', HTMLButtonElement),
   authentication: getElement('authentication', HTMLDetailsElement),
+  devices: getElement('devices', HTMLFieldSetElement),
   login: getElement('login', HTMLDivElement),
   refreshSettings: getElement('refresh_settings_common', HTMLButtonElement),
   resetCredentials: getElement('reset_credentials', HTMLButtonElement),
@@ -445,11 +447,15 @@ const generateCommonSettings = (
   }
 }
 
+// The credentials section folds once signed in; the device settings
+// stay hidden until then (mirrors melcloud's #content gating), so a
+// signed-out page shows only the expanded credentials.
 const setAuthenticatedState = (
   elements: PageElements,
   isAuthenticated: boolean,
 ): void => {
   elements.authentication.open = !isAuthenticated
+  elements.devices.hidden = !isAuthenticated
 }
 
 const pushCredentials = async (


### PR DESCRIPTION
On-device review surfaced that the settings page wasn't structurally aligned with com.melcloud. This fixes what a headless render of the real bundle confirmed:

- **Credentials section discoverability** — the device-settings fieldset was always visible (even signed out, with no devices); it is now `hidden` until authenticated, mirroring melcloud's `#content` gating. A signed-out page shows only the prominent, expanded credentials form; signing in collapses it and reveals the settings.
- **Labels** — legend "All device settings" / "Paramètres de tous les appareils"; the apply button is "Update" / "Mettre à jour" (`settings.update`); the credentials Reset button reads "Reset" / "Réinitialiser" (was "Log out" / "Se déconnecter").
- **Buttons** — melcloud's shadow (non-`-full`) classes in the two-column `.container` (side by side).

Verified via a headless DOM render driving the real IIFE bundle: signed-in → collapsed credentials (2 fields + Réinitialiser) + shown "Paramètres de tous les appareils" with "Mettre à jour"; signed-out → expanded credentials, device section hidden. Coverage 100% ×4, `homey:validate` publish ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)