### PR TITLE
Fix the credentials panel: title size and pre-filled values

### DIFF
--- a/settings/index.css
+++ b/settings/index.css
@@ -1,6 +1,17 @@
 /* Homey injects its own class-based stylesheet at runtime; this file
    only fills documented SDK gaps and page-specific layout. */
 
+/* The credentials panel's summary doubles as the fieldset legend, but
+   Homey's `legend.homey-form-legend` rule is tag-qualified and misses a
+   `summary` — restate the legend's tokens so the "Credentials" title
+   renders at the same size as the sibling legends instead of the tiny
+   default. */
+summary.homey-form-legend {
+  cursor: pointer;
+  font-size: var(--homey-font-size-medium);
+  font-weight: var(--homey-font-weight-bold);
+}
+
 /* The injected sheet resets fieldsets with `all: unset`, leaving
    `display: inline` — and WebKit renders inline fieldsets atomically,
    so sibling sets tile side by side. The ancestor selector outweighs

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -41,6 +41,11 @@ interface PageState {
   usernameElement: HTMLInputElement | null
 }
 
+interface StoredCredentials {
+  password?: string | null
+  username?: string | null
+}
+
 // Mobile keyboards mangle the email username: iOS autocapitalizes and
 // autocorrects it, and autocomplete appends a trailing space. The hints
 // disable that, and the login path trims what slips through.
@@ -246,15 +251,18 @@ const createInputElement = ({
   id,
   placeholder,
   type,
+  value,
 }: {
   id: string
   type: string
   placeholder?: string | undefined
+  value?: string | null | undefined
 }): HTMLInputElement => {
   const inputElement = document.createElement('input')
   inputElement.classList.add('homey-form-input')
   inputElement.id = id
   inputElement.type = type
+  inputElement.value = value ?? ''
   if (placeholder !== undefined) {
     inputElement.placeholder = placeholder
   }
@@ -413,17 +421,25 @@ const applyDeviceSettings = async (context: PageContext): Promise<void> => {
 const generateCredential = (
   { elements }: PageContext,
   driverSettings: Partial<Record<string, DriverSetting[]>>,
-  credentialKey: keyof LoginCredentials,
+  credential: {
+    key: keyof LoginCredentials
+    value: string | null | undefined
+  },
 ): HTMLInputElement | null => {
   const loginSetting = driverSettings.login?.find(
-    ({ id: settingId }) => settingId === credentialKey,
+    ({ id: settingId }) => settingId === credential.key,
   )
   if (loginSetting === undefined) {
     return null
   }
   const { id, placeholder, title, type } = loginSetting
-  const valueElement = createInputElement({ id, placeholder, type })
-  applyCredentialHints(valueElement, credentialKey)
+  const valueElement = createInputElement({
+    id,
+    placeholder,
+    type,
+    value: credential.value,
+  })
+  applyCredentialHints(valueElement, credential.key)
   createGroupElement(elements.login, valueElement, title)
   return valueElement
 }
@@ -544,21 +560,35 @@ const addEventListeners = (context: PageContext): void => {
   })
 }
 
+// The persisted username/password (the lib's SettingManager writes them
+// into homey.settings) so the credential fields show the signed-in
+// account instead of empty placeholders.
+const fetchStoredCredentials = async (
+  homey: HomeySettings,
+): Promise<StoredCredentials> =>
+  new Promise((resolve) => {
+    homey.get((error: Error | null, settings: StoredCredentials | null) => {
+      resolve(error === null && settings !== null ? settings : {})
+    })
+  })
+
 const buildSections = async (context: PageContext): Promise<void> => {
   const { homey, state } = context
-  const driverSettings = await homeyApiGet<
-    Partial<Record<string, DriverSetting[]>>
-  >(homey, '/settings/drivers')
-  state.usernameElement = generateCredential(
-    context,
-    driverSettings,
-    'username',
-  )
-  state.passwordElement = generateCredential(
-    context,
-    driverSettings,
-    'password',
-  )
+  const [driverSettings, credentials] = await Promise.all([
+    homeyApiGet<Partial<Record<string, DriverSetting[]>>>(
+      homey,
+      '/settings/drivers',
+    ),
+    fetchStoredCredentials(homey),
+  ])
+  state.usernameElement = generateCredential(context, driverSettings, {
+    key: 'username',
+    value: credentials.username,
+  })
+  state.passwordElement = generateCredential(context, driverSettings, {
+    key: 'password',
+    value: credentials.password,
+  })
   await fetchDeviceSettings(context)
   generateCommonSettings(context, driverSettings)
 }


### PR DESCRIPTION
On-device cold-open review surfaced two credentials-panel regressions from the 23.0.0 rewrite:

- **Title too small** — the panel's `<summary class="homey-form-legend">` doubles as the fieldset legend, but Homey's injected `legend.homey-form-legend` rule is tag-qualified and never matches a `summary`, so the "Identifiants" title rendered at the tiny default size. Fixed by restating the legend tokens for `summary.homey-form-legend` (`--homey-font-size-medium` + bold), the same fix com.melcloud carries.
- **Fields showed placeholders while authenticated** — the rewrite dropped the pre-fill: `createInputElement` never set `.value`, so a signed-in user saw empty fields with placeholder text. Now the persisted username/password (written into `homey.settings` by the lib's SettingManager) are read via `homey.get` and pre-filled, mirroring melcloud and the pre-rewrite page.

Verified with a headless render of the real IIFE bundle: signed-in credential fields carry the stored username/password values (placeholder as fallback). Coverage 100% ×4, `homey:validate` publish ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)