### PR TITLE
Neutralize the login placeholders (com.melcloud#1460)

### DIFF
--- a/.homeycompose/drivers/templates/defaults.json
+++ b/.homeycompose/drivers/templates/defaults.json
@@ -18,18 +18,11 @@
           "en": "Password",
           "fr": "Mot de passe"
         },
-        "passwordPlaceholder": {
-          "en": "P4ssw0rd",
-          "fr": "P4ssw0rd"
-        },
         "usernameLabel": {
           "en": "Username",
           "fr": "Nom d'utilisateur"
         },
-        "usernamePlaceholder": {
-          "en": "user@domain.com",
-          "fr": "utilisateur@domain.fr"
-        }
+        "usernamePlaceholder": "name@example.com"
       },
       "template": "login_credentials"
     },

--- a/app.json
+++ b/app.json
@@ -832,18 +832,11 @@
               "en": "Password",
               "fr": "Mot de passe"
             },
-            "passwordPlaceholder": {
-              "en": "P4ssw0rd",
-              "fr": "P4ssw0rd"
-            },
             "usernameLabel": {
               "en": "Username",
               "fr": "Nom d'utilisateur"
             },
-            "usernamePlaceholder": {
-              "en": "user@domain.com",
-              "fr": "utilisateur@domain.fr"
-            }
+            "usernamePlaceholder": "name@example.com"
           },
           "template": "login_credentials"
         },

--- a/app.mts
+++ b/app.mts
@@ -21,9 +21,10 @@ import { type Homey, App } from './lib/homey.mts'
 const NOTIFICATION_DELAY_MS = 10_000
 
 const localize = (
-  strings: Partial<Record<string, string>> & { readonly en: string },
+  strings: string | (Partial<Record<string, string>> & { readonly en: string }),
   language: string,
-): string => strings[language] ?? strings.en
+): string =>
+  typeof strings === 'string' ? strings : (strings[language] ?? strings.en)
 
 // Aggregates one device's settings into the per-driver map; a conflicting
 // value across devices marks the setting as indeterminate (`null`) and stops

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -50,9 +50,8 @@ const heatzyLoginPair: LoginSetting = {
   id: 'login',
   options: {
     passwordLabel: { en: 'Password', fr: 'Mot de passe' },
-    passwordPlaceholder: { en: 'Your password' },
     usernameLabel: { en: 'Username', fr: 'Nom' },
-    usernamePlaceholder: { en: 'Your username' },
+    usernamePlaceholder: 'name@example.com',
   },
 }
 
@@ -640,9 +639,11 @@ describe(HeatzyApp, () => {
       assertDefined(username)
 
       expect(password.title).toBe('Mot de passe')
-      expect(password.placeholder).toBe('Your password')
+      // No password placeholder; the username placeholder is a single
+      // ASCII example, returned as-is by localize regardless of language.
+      expect(password.placeholder).toBeUndefined()
       expect(username.title).toBe('Nom')
-      expect(username.placeholder).toBe('Your username')
+      expect(username.placeholder).toBe('name@example.com')
     })
   })
 

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -4,9 +4,13 @@ export interface LoginSetting extends PairSetting {
   readonly id: 'login'
   readonly options: {
     readonly passwordLabel: LocalizedStrings
-    readonly passwordPlaceholder: LocalizedStrings
     readonly usernameLabel: LocalizedStrings
-    readonly usernamePlaceholder: LocalizedStrings
+    readonly usernamePlaceholder: string
+    // A password has no format to illustrate and the label already names the
+    // field, so it carries no placeholder. The username placeholder is a
+    // single neutral ASCII example (an email is ASCII), not per-locale
+    // strings — the labels hold the localization.
+    readonly passwordPlaceholder?: string
   }
 }
 


### PR DESCRIPTION
Ports com.melcloud#1460 to com.heatzy — rethinks the pair/repair login placeholders.

| field | before | after |
|---|---|---|
| username | per-locale email (`utilisateur@domain.fr`) | **`name@example.com`** — one neutral ASCII value |
| password | `P4ssw0rd` | **removed** |

**Why** — an email address is ASCII (the domain must be ASCII/punycode), so a localized example modelled invalid addresses; a single neutral value on the RFC 2606 reserved `example.com` is correct and needs no locale tags (plain string → `localize()` now accepts `string | LocalizedStrings`). A password has no format to illustrate and the label already names the field, so its placeholder only restated the obvious — and the literal `"P4ssw0rd"` tripped SonarCloud's hardcoded-credential detector (false positive), so it's dropped.

Coverage 100% ×4 (the new `localize` string branch is covered), `homey:validate` publish ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)