### PR TITLE
chore(release): 23.0.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -78,5 +78,9 @@
   "23.0.0": {
     "en": "The app has been rewritten: sessions are handled better, signing in is more resilient, and the settings page is more reliable.",
     "fr": "L'application a été réécrite : les sessions sont mieux gérées, la connexion est plus robuste et la page de réglages est plus fiable."
+  },
+  "23.0.1": {
+    "en": "Refined the settings collapse/expand chevron.",
+    "fr": "Chevron d'ouverture/fermeture des réglages affiné."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -91,5 +91,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.0"
+  "version": "23.0.1"
 }

--- a/app.json
+++ b/app.json
@@ -92,7 +92,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.0",
+  "version": "23.0.1",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.0.0",
+      "version": "23.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {


### PR DESCRIPTION
Release **23.0.1** — settings collapse/expand chevron (#1031).

Bump + `.homeychangelog.json` (en/fr) + `homey validate --level publish` (green). On tag + GitHub release, `publish.yml` pushes to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)