### PR TITLE
chore: release 23.0.2

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -82,5 +82,9 @@
   "23.0.1": {
     "en": "Refined the settings collapse/expand chevron.",
     "fr": "Chevron d'ouverture/fermeture des réglages affiné."
+  },
+  "23.0.2": {
+    "en": "Settings: the Update button now stays greyed out until you change a setting.",
+    "fr": "Réglages : le bouton Mettre à jour reste désormais grisé tant que vous n'avez pas modifié un réglage."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -91,5 +91,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.1"
+  "version": "23.0.2"
 }

--- a/app.json
+++ b/app.json
@@ -92,7 +92,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.1",
+  "version": "23.0.2",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.1",
+  "version": "23.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.0.1",
+      "version": "23.0.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.1",
+  "version": "23.0.2",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {


### PR DESCRIPTION
Release **23.0.2**.

## Changelog (store-facing)
Settings: the Update button now stays greyed out until you change a setting.

## Contents
- `.homeychangelog.json` — new `23.0.2` entry (en + fr).
- `.homeycompose/app.json` / `app.json` — version bump to 23.0.2.
- `package.json` / `package-lock.json` — aligned via `npm version`.

Ships the already-merged dirty-gating (#1034). No code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)