### PR TITLE
refactor: adopt the shared dirty-gate primitive in settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,9 @@ coverage.
   `[class*='homey-button']:disabled` generically, never a per-class list
   (a class list silently missed renamed buttons).
   `tests/unit/dirty-gate.test.ts` locks the behavior; the module is a
-  byte-identical copy of com.melcloud's `public/dirty-gate.mts` — edit
-  both together.
+  byte-identical copy of com.melcloud's `public/dirty-gate.mts`
+  (com.melcloud.extension carries the third copy) — edit all three
+  together.
 - The injected sheet resets `fieldset.homey-form-checkbox-set` /
   `-radio-set` with `all: unset`, which leaves `display: inline` — and
   WebKit renders inline fieldsets atomically, so SIBLING sets tile side

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,16 @@ coverage.
   SDK gaps and app-specific design — Homey injects its own class-based
   stylesheet at runtime, which is not in the repo and not available
   offline.
+- Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
+  settings Apply/Refresh pair — never re-derive its invariant at a call
+  site. Its `serialize` must stay a PURE form snapshot, never a
+  request-body builder (reusing `buildSettingsBody` was the historical
+  never-pristine bug: it filters null deltas), and disabled greying styles
+  `[class*='homey-button']:disabled` generically, never a per-class list
+  (a class list silently missed renamed buttons).
+  `tests/unit/dirty-gate.test.ts` locks the behavior; the module is a
+  byte-identical copy of com.melcloud's `public/dirty-gate.mts` — edit
+  both together.
 - The injected sheet resets `fieldset.homey-form-checkbox-set` /
   `-radio-set` with `all: unset`, which leaves `display: inline` — and
   WebKit renders inline fieldsets atomically, so SIBLING sets tile side

--- a/settings/dirty-gate.mts
+++ b/settings/dirty-gate.mts
@@ -1,0 +1,88 @@
+// The webviews' shared dirty-gating primitive: one gate owns one Apply
+// button — greyed while the form matches its saved baseline OR a request
+// is in flight — and its sibling Refresh buttons, greyed by busy alone so
+// they stay the escape hatch on a pristine form. The factory owns the
+// whole invariant; a call site only supplies `serialize`. Byte-identical
+// copies of this module live in the sibling Homey apps — edit them
+// together.
+
+export interface DirtyGate {
+  readonly markSaved: () => void
+  readonly recompute: () => void
+  readonly runBusy: (action: () => Promise<void>) => Promise<void>
+  readonly setBusy: (isBusy: boolean) => void
+  readonly wire: (targets: readonly EventTarget[]) => void
+}
+
+export interface DirtyGateOptions {
+  readonly applyElement: HTMLButtonElement
+  readonly refreshElements?: readonly HTMLButtonElement[]
+  readonly serialize: () => string
+}
+
+// `input` covers live typing in number/date fields; `change` covers the
+// selects and the final commit (and, since `serialize` reads the whole
+// form, any field a cascade handler mutated).
+const wireRecompute = (
+  targets: readonly EventTarget[],
+  recompute: () => void,
+): void => {
+  for (const target of targets) {
+    for (const eventName of ['change', 'input']) {
+      target.addEventListener(eventName, recompute)
+    }
+  }
+}
+
+// `serialize` must be a PURE snapshot of the form's current values — never
+// a request-body builder: those filter defaults and null deltas out, which
+// desyncs the pristine check. The gate snapshots it at creation, so Apply
+// starts greyed even when no data ever loads; call `markSaved` after every
+// (re)populate and successful save, `wire` on the controls the snapshot
+// reads, and route every request through `runBusy`.
+export const createDirtyGate = ({
+  applyElement,
+  refreshElements = [],
+  serialize,
+}: DirtyGateOptions): DirtyGate => {
+  let busyGeneration = 0
+  let isBusy = false
+  let saved = serialize()
+  // Native `disabled` (not a CSS class): it blocks keyboard activation
+  // during in-flight actions and is announced by screen readers.
+  const recompute = (): void => {
+    applyElement.disabled = isBusy || serialize() === saved
+  }
+  const markSaved = (): void => {
+    saved = serialize()
+    recompute()
+  }
+  // Refresh is gated by busy ALONE (never dirty); Apply folds the busy
+  // flag into its dirty check so a mid-request edit cannot re-enable it.
+  const setBusy = (isBusyNow: boolean): void => {
+    isBusy = isBusyNow
+    for (const element of refreshElements) {
+      element.disabled = isBusyNow
+    }
+    recompute()
+  }
+  // Generation-tokened: only the action holding the latest claim may
+  // release the busy state, so an overlapping action can never free the
+  // buttons a live request still owns.
+  const runBusy = async (action: () => Promise<void>): Promise<void> => {
+    const generation = ++busyGeneration
+    setBusy(true)
+    try {
+      await action()
+    } finally {
+      if (generation === busyGeneration) {
+        setBusy(false)
+      }
+    }
+  }
+  const wire = (targets: readonly EventTarget[]): void => {
+    wireRecompute(targets, recompute)
+  }
+  recompute()
+  return { markSaved, recompute, runBusy, setBusy, wire }
+}

--- a/settings/index.css
+++ b/settings/index.css
@@ -59,13 +59,10 @@ details[open] > summary.homey-form-legend::before {
 }
 
 /* Busy and dirty-gated buttons use the native `disabled` attribute; the
-   injected sheet does not grey them, so paint the disabled state here.
-   The classes must match the actual buttons (Apply is danger-shadow,
-   Refresh is secondary-shadow, Reset/Log in are primary-full) — the
-   `-full` shadow variants matched nothing, so disabled never greyed. */
-.homey-button-danger-shadow:disabled,
-.homey-button-primary-full:disabled,
-.homey-button-secondary-shadow:disabled {
+   injected sheet does not grey them, so paint the disabled state here on
+   EVERY homey-button variant. The attribute selector keeps the rule
+   variant-proof: a per-class list silently missed renamed buttons. */
+[class*='homey-button']:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -4,6 +4,7 @@ import type HomeySettings from 'homey/lib/HomeySettings'
 import type { DeviceSettings, Settings } from '../types/device-settings.mts'
 import type { DriverSetting } from '../types/driver-settings.mts'
 import { getErrorMessage } from '../lib/get-error-message.mts'
+import { type DirtyGate, createDirtyGate } from './dirty-gate.mts'
 
 // Runtime floor: esbuild lowers syntax to es2020, but runtime APIs must
 // stay ≤ es2023 — no iterator helpers, no Object.groupBy (old iOS
@@ -19,6 +20,7 @@ type HTMLValueElement = HTMLInputElement | HTMLSelectElement
 
 interface PageContext {
   readonly elements: PageElements
+  readonly gate: DirtyGate
   readonly homey: HomeySettings
   readonly state: PageState
 }
@@ -37,9 +39,7 @@ interface PageElements {
 interface PageState {
   deviceSettings: DeviceSettings
   flatDeviceSettings: Record<string, unknown>
-  isBusy: boolean
   passwordElement: HTMLInputElement | null
-  savedState: string
   usernameElement: HTMLInputElement | null
 }
 
@@ -378,7 +378,7 @@ const buildSettingsBody = ({ elements, state }: PageContext): Settings => {
 // included, never filtered): the dirty check compares it against the
 // value captured when the form was last populated. Sorted by id so
 // control order never perturbs the string.
-const serializeCommonSettings = ({ elements }: PageContext): string => {
+const serializeCommonSettings = (elements: PageElements): string => {
   const entries: [string, unknown][] = []
   for (const element of commonSettingElements(elements)) {
     const id = settingIdOf(element)
@@ -390,54 +390,14 @@ const serializeCommonSettings = ({ elements }: PageContext): string => {
   return JSON.stringify(entries)
 }
 
-// Apply means something only once the form diverges from its loaded
-// snapshot: a value equal to the snapshot — or an in-flight request —
-// greys the button out. The snapshot is retaken whenever the form is
-// (re)populated, so a pristine load stays greyed even when a common
-// setting is mixed/null across devices.
-const updateSettingsDirty = (context: PageContext): void => {
-  const isPristine =
-    serializeCommonSettings(context) === context.state.savedState
-  disableButton(
-    context.elements.applySettings,
-    context.state.isBusy || isPristine,
-  )
-}
-
-// A request in flight locks both settings buttons; the dirty recompute
-// folds the busy flag in so a control change mid-request cannot
-// re-enable Apply.
-const setSettingsButtonsBusy = (
-  context: PageContext,
-  isBusy: boolean,
-): void => {
-  context.state.isBusy = isBusy
-  // Refresh is gated by busy alone, never by the dirty state.
-  disableButton(context.elements.refreshSettings, isBusy)
-  updateSettingsDirty(context)
-}
-
-const withBusySettingsButtons = async (
-  context: PageContext,
-  action: () => Promise<void>,
-): Promise<void> => {
-  setSettingsButtonsBusy(context, true)
-  try {
-    await action()
-  } finally {
-    setSettingsButtonsBusy(context, false)
-  }
-}
-
 const refreshCommonSettings = (context: PageContext): void => {
-  const { elements, state } = context
+  const { elements, gate, state } = context
   for (const element of commonSettingElements(elements)) {
     refreshCommonSetting(element, state.flatDeviceSettings)
   }
-  // Repopulating realigns the form with the stored settings — snapshot it
-  // as the new baseline so Apply reflects the freshly pristine state.
-  state.savedState = serializeCommonSettings(context)
-  updateSettingsDirty(context)
+  // Repopulating realigns the form with the stored settings — re-baseline
+  // so Apply reflects the freshly pristine state.
+  gate.markSaved()
 }
 
 const updateDeviceSettings = (state: PageState, body: Settings): void => {
@@ -465,7 +425,7 @@ const pushDeviceSettings = async (
   updateDeviceSettings(state, body)
   // The just-saved values are the new pristine baseline — snapshot so
   // Apply greys back out until the form diverges again.
-  state.savedState = serializeCommonSettings(context)
+  context.gate.markSaved()
   await alertError(homey, homey.__('settings.success'))
 }
 
@@ -479,9 +439,7 @@ const applyDeviceSettings = async (context: PageContext): Promise<void> => {
     await alertError(homey, homey.__('settings.devices.apply.nothing'))
     return
   }
-  await withBusySettingsButtons(context, async () =>
-    pushDeviceSettings(context, body),
-  )
+  await context.gate.runBusy(async () => pushDeviceSettings(context, body))
 }
 
 const generateCredential = (
@@ -524,9 +482,7 @@ const generateCommonSettings = (
     ) {
       const valueElement = createSelectElement(homey, settingId, values)
       // Every control feeds the dirty check that gates Apply.
-      valueElement.addEventListener('change', () => {
-        updateSettingsDirty(context)
-      })
+      context.gate.wire([valueElement])
       createGroupElement(elements.settingsCommon, valueElement, title)
       refreshCommonSetting(valueElement, state.flatDeviceSettings)
     }
@@ -662,20 +618,23 @@ const buildSections = async (context: PageContext): Promise<void> => {
   await fetchDeviceSettings(context)
   generateCommonSettings(context, driverSettings)
   // Snapshot the pristine state once the sections are built.
-  state.savedState = serializeCommonSettings(context)
-  updateSettingsDirty(context)
+  context.gate.markSaved()
 }
 
 const init = async (homey: HomeySettings): Promise<void> => {
+  const elements = getPageElements()
   const context: PageContext = {
-    elements: getPageElements(),
+    elements,
+    gate: createDirtyGate({
+      applyElement: elements.applySettings,
+      refreshElements: [elements.refreshSettings],
+      serialize: (): string => serializeCommonSettings(elements),
+    }),
     homey,
     state: {
       deviceSettings: {},
       flatDeviceSettings: {},
-      isBusy: false,
       passwordElement: null,
-      savedState: '',
       usernameElement: null,
     },
   }

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDirtyGate } from '../../settings/dirty-gate.mts'
+
+// The gate is headless: buttons only need a `disabled` slot, and wired
+// targets only need to dispatch events, so plain doubles are enough.
+const setup = (): {
+  applyElement: HTMLButtonElement
+  form: { value: string }
+  gate: ReturnType<typeof createDirtyGate>
+  refreshElement: HTMLButtonElement
+} => {
+  const applyElement = { disabled: false } as unknown as HTMLButtonElement
+  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const form = { value: 'pristine' }
+  const gate = createDirtyGate({
+    applyElement,
+    refreshElements: [refreshElement],
+    serialize: () => form.value,
+  })
+  return { applyElement, form, gate, refreshElement }
+}
+
+describe('dirty gate', () => {
+  it('should start pristine with Apply greyed and Refresh live', () => {
+    const { applyElement, refreshElement } = setup()
+
+    expect(applyElement.disabled).toBe(true)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should enable Apply when the form diverges and grey it once saved', () => {
+    const { applyElement, form, gate } = setup()
+
+    form.value = 'edited'
+    gate.recompute()
+
+    expect(applyElement.disabled).toBe(false)
+
+    gate.markSaved()
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should recompute on change and input events from wired targets', () => {
+    const { applyElement, form, gate } = setup()
+    const target = new EventTarget()
+    gate.wire([target])
+
+    form.value = 'edited'
+    target.dispatchEvent(new Event('change'))
+
+    expect(applyElement.disabled).toBe(false)
+
+    form.value = 'pristine'
+    target.dispatchEvent(new Event('input'))
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should grey both buttons while busy and restore them after', () => {
+    const { applyElement, form, gate, refreshElement } = setup()
+
+    form.value = 'edited'
+    gate.setBusy(true)
+
+    expect(applyElement.disabled).toBe(true)
+    expect(refreshElement.disabled).toBe(true)
+
+    gate.setBusy(false)
+
+    expect(applyElement.disabled).toBe(false)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should release the buttons when the action rejects and keep the edit dirty', async () => {
+    const { applyElement, form, gate, refreshElement } = setup()
+
+    form.value = 'edited'
+
+    await expect(
+      gate.runBusy(async () => {
+        await Promise.reject(new Error('boom'))
+      }),
+    ).rejects.toThrow('boom')
+
+    expect(applyElement.disabled).toBe(false)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should let only the latest claim release the busy state', async () => {
+    const { gate, refreshElement } = setup()
+    const firstClaim = Promise.withResolvers<null>()
+    const secondClaim = Promise.withResolvers<null>()
+    const first = gate.runBusy(async () => {
+      await firstClaim.promise
+    })
+    const second = gate.runBusy(async () => {
+      await secondClaim.promise
+    })
+
+    firstClaim.resolve(null)
+    await first
+
+    expect(refreshElement.disabled).toBe(true)
+
+    secondClaim.resolve(null)
+    await second
+
+    expect(refreshElement.disabled).toBe(false)
+  })
+})


### PR DESCRIPTION
Factors the dirty-gating shipped in #1034 into the **shared headless primitive** so its invariant can no longer be re-derived (and subtly broken) locally.

## What
- **`settings/dirty-gate.mts`** — byte-identical copy of com.melcloud's `public/dirty-gate.mts` (sibling melcloud PR): `createDirtyGate({applyElement, refreshElements, serialize})` owns Apply-pristine/busy gating, Refresh busy-only gating, saved-baseline snapshots, generation-tokened busy claims, and control wiring.
- **`settings/index.mts`** — drops the page-local trio (`updateSettingsDirty`, `setSettingsButtonsBusy`, `withBusySettingsButtons`) and the `savedState`/`isBusy` page state; the gate lives on `PageContext`. `serialize` stays the only page-specific piece, documented as a **pure form snapshot** (reusing `buildSettingsBody` here was the historical never-pristine bug).
- **`settings/index.css`** — disabled greying now targets `[class*='homey-button']:disabled` (same specificity) instead of a per-class list — the pre-existing `-full` selector bug class becomes impossible.
- **`tests/unit/dirty-gate.test.ts`** — 6 behavior-locking tests, identical to the melcloud twin.
- **CLAUDE.md** — doctrine: module ownership, serialize purity, generic `:disabled`, edit-both-copies rule.

No behavior change intended. Full suite green (167 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
