### PR TITLE
style: drop the experimentalTernaries flag

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -12,9 +12,9 @@ import { getErrorMessage } from './lib/get-error-message.mts'
 // login failures are classified here, where `instanceof` still works: a
 // credential rejection reads differently from a transport failure.
 const toLoginFailure = (homey: Homey, error: unknown): Error =>
-  error instanceof AuthenticationError ?
-    new Error(homey.__('settings.authenticate.rejected'))
-  : new Error(getErrorMessage(error))
+  error instanceof AuthenticationError
+    ? new Error(homey.__('settings.authenticate.rejected'))
+    : new Error(getErrorMessage(error))
 
 // Diagnostics breadcrumb: the settings webview is otherwise invisible in
 // diagnostic reports (its routes never touch Heatzy), which makes

--- a/app.mts
+++ b/app.mts
@@ -308,9 +308,9 @@ export default class HeatzyApp extends App {
   #getDevices(ids?: readonly string[]): HeatzyDevice[] {
     return Object.values(this.homey.drivers.getDrivers()).flatMap((driver) => {
       const devices = driver.getDevices()
-      return ids === undefined ? devices : (
-          devices.filter(({ id }) => ids.includes(id))
-        )
+      return ids === undefined
+        ? devices
+        : devices.filter(({ id }) => ids.includes(id))
     })
   }
 

--- a/drivers/heatzy/device.mts
+++ b/drivers/heatzy/device.mts
@@ -125,13 +125,13 @@ export default class HeatzyDevice extends Device {
     heater_operation_mode: (value) =>
       isDerogationModeKey(value) ? { derog_mode: DerogationMode[value] } : {},
     locked: (value, product) =>
-      product === Product.glow ?
-        { LOCK_C: toSwitch(value) }
-      : { lock_switch: toSwitch(value) },
+      product === Product.glow
+        ? { LOCK_C: toSwitch(value) }
+        : { lock_switch: toSwitch(value) },
     onoff: (value, product) =>
-      product === Product.glow ?
-        { on_off: toSwitch(value) }
-      : { mode: value === true ? this.#onValue : Mode.stop },
+      product === Product.glow
+        ? { on_off: toSwitch(value) }
+        : { mode: value === true ? this.#onValue : Mode.stop },
     'onoff.timer': (value) => ({ timer_switch: toSwitch(value) }),
     'onoff.window_detection': (value) => ({ window_switch: toSwitch(value) }),
     target_temperature: (value, product) =>
@@ -139,9 +139,9 @@ export default class HeatzyDevice extends Device {
     'target_temperature.eco': (value, product) =>
       getTargetTemperature(product, Mode.eco, Number(value)),
     thermostat_mode: (value) =>
-      isMode(value) ?
-        { mode: value === Mode.stop ? this.#offValue : value }
-      : {},
+      isMode(value)
+        ? { mode: value === Mode.stop ? this.#offValue : value }
+        : {},
   }
 
   get #offValue(): Mode {
@@ -265,9 +265,9 @@ export default class HeatzyDevice extends Device {
       // always_on devices never switch off from Homey: the outgoing
       // value is coerced before the converter runs.
       const value =
-        capability === 'onoff' && this.getSetting('always_on') ?
-          true
-        : values[capability]
+        capability === 'onoff' && this.getSetting('always_on')
+          ? true
+          : values[capability]
       updateData = {
         ...updateData,
         ...this.#toDevice[capability](value, device.product),
@@ -365,9 +365,9 @@ export default class HeatzyDevice extends Device {
     await sequential(
       [...currentCapabilities.symmetricDifference(requiredCapabilities)],
       async (capability) => {
-        await (requiredCapabilities.has(capability) ?
-          this.addCapability(capability)
-        : this.removeCapability(capability))
+        await (requiredCapabilities.has(capability)
+          ? this.addCapability(capability)
+          : this.removeCapability(capability))
       },
     )
   }

--- a/drivers/heatzy/driver.mts
+++ b/drivers/heatzy/driver.mts
@@ -59,18 +59,18 @@ export const getCapabilitiesOptions = (
 ): CapabilitiesOptions => {
   const values: CapabilitiesOptionsValues<Mode>[] = [
     { id: Mode.comfort, title: { en: 'Comfort', fr: 'Confort' } },
-    ...(product >= Product.v4 ?
-      [
-        {
-          id: Mode.comfortMinus1,
-          title: { en: 'Comfort -1°C', fr: 'Confort -1°C' },
-        },
-        {
-          id: Mode.comfortMinus2,
-          title: { en: 'Comfort -2°C', fr: 'Confort -2°C' },
-        },
-      ]
-    : []),
+    ...(product >= Product.v4
+      ? [
+          {
+            id: Mode.comfortMinus1,
+            title: { en: 'Comfort -1°C', fr: 'Confort -1°C' },
+          },
+          {
+            id: Mode.comfortMinus2,
+            title: { en: 'Comfort -2°C', fr: 'Confort -2°C' },
+          },
+        ]
+      : []),
     { id: Mode.eco, title: { en: 'Eco', fr: 'Éco' } },
     {
       id: Mode.frostProtection,
@@ -81,14 +81,14 @@ export const getCapabilitiesOptions = (
   const derogationValues: CapabilitiesOptionsValues<
     CapabilitiesOptions['heater_operation_mode']['values'][number]['id']
   >[] = [
-    ...(product >= Product.pro ?
-      ([
-        {
-          id: 'presence',
-          title: { en: 'Presence detection', fr: 'Détection de présence' },
-        },
-      ] as const)
-    : []),
+    ...(product >= Product.pro
+      ? ([
+          {
+            id: 'presence',
+            title: { en: 'Presence detection', fr: 'Détection de présence' },
+          },
+        ] as const)
+      : []),
     { id: 'boost', title: 'Boost' },
     { id: 'vacation', title: { en: 'Vacation', fr: 'Vacances' } },
     { id: 'off', title: { en: 'Off', fr: 'Désactivé' } },
@@ -110,26 +110,26 @@ export const getCapabilitiesOptions = (
 export const getRequiredCapabilities = (product: Product): string[] => [
   'onoff',
   'thermostat_mode',
-  ...(product >= Product.v2 ?
-    [
-      'locked',
-      'onoff.timer',
-      'heater_operation_mode',
-      'derog_end',
-      'derog_time',
-    ]
-  : []),
-  ...(product >= Product.glow ?
-    ['measure_temperature', 'target_temperature', 'target_temperature.eco']
-  : []),
-  ...(product >= Product.pro ?
-    [
-      'alarm_presence',
-      'measure_humidity',
-      'onoff.window_detection',
-      'operational_state',
-    ]
-  : []),
+  ...(product >= Product.v2
+    ? [
+        'locked',
+        'onoff.timer',
+        'heater_operation_mode',
+        'derog_end',
+        'derog_time',
+      ]
+    : []),
+  ...(product >= Product.glow
+    ? ['measure_temperature', 'target_temperature', 'target_temperature.eco']
+    : []),
+  ...(product >= Product.pro
+    ? [
+        'alarm_presence',
+        'measure_humidity',
+        'onoff.window_detection',
+        'operational_state',
+      ]
+    : []),
 ]
 
 export default class HeatzyDriver extends Driver {
@@ -200,8 +200,8 @@ export default class HeatzyDriver extends Driver {
               },
             ) => {
               const value = args.device.getCapabilityValue(capability)
-              return typeof value === 'string' || typeof value === 'number' ?
-                  value === args[getArg(capability)]
+              return typeof value === 'string' || typeof value === 'number'
+                ? value === args[getArg(capability)]
                 : value
             },
           )

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from 'prettier'
 
 const config: Config = {
-  experimentalTernaries: true,
   plugins: ['prettier-plugin-packagejson'],
   semi: false,
   singleQuote: true,

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -323,13 +323,11 @@ const refreshCommonSetting = (
   if (id !== undefined) {
     const value = flatDeviceSettings[id]
     element.value =
-      (
-        typeof value === 'boolean' ||
-        typeof value === 'number' ||
-        typeof value === 'string'
-      ) ?
-        String(value)
-      : ''
+      typeof value === 'boolean' ||
+      typeof value === 'number' ||
+      typeof value === 'string'
+        ? String(value)
+        : ''
   }
 }
 
@@ -350,8 +348,8 @@ const fetchDeviceSettings = async ({
 
 const processValue = (element: HTMLSelectElement): unknown => {
   if (element.value !== '') {
-    return booleanStrings.includes(element.value) ?
-        element.value === 'true'
+    return booleanStrings.includes(element.value)
+      ? element.value === 'true'
       : element.value
   }
   return null


### PR DESCRIPTION
Removes `experimentalTernaries: true` from `prettier.config.ts` and reformats (6 files). Family-wide change — rationale in OlivierZal/com.melcloud#1471. Formatting-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)