### PR TITLE
docs: prune comments to the doctrine (intent and constraint only)

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -374,7 +374,6 @@ export default class HeatzyApp extends App {
     return false
   }
 
-  // Per-device sync failures are logged without aborting the full run.
   async #syncFromDevices(ids?: readonly string[]): Promise<void> {
     const results = await Promise.allSettled(
       this.#getDevices(ids).map(async (device) => device.syncFromDevice()),

--- a/lib/errors.mts
+++ b/lib/errors.mts
@@ -1,7 +1,6 @@
-// Thrown when a device or zone lookup fails. Lets `ensureDevice` distinguish
+// Thrown when a device lookup fails. Lets `ensureDevice` distinguish
 // expected lookup failures (user-visible warning) from programming errors
-// (logged only), while Homey's API layer still serializes the localized
-// message for settings/widget clients.
+// (logged only).
 export class NotFoundError extends Error {
   public override name = 'NotFoundError'
 }

--- a/lib/fire-and-forget.mts
+++ b/lib/fire-and-forget.mts
@@ -1,6 +1,6 @@
-// The one sanctioned fire-and-forget seam (melcloud-api's shape):
-// detach already-started work from the caller's critical path, logging
-// a rejection instead of propagating it.
+// The one sanctioned fire-and-forget seam: detach already-started work
+// from the caller's critical path, logging a rejection instead of
+// propagating it.
 export const fireAndForget = (
   promise: Promise<unknown>,
   logError: (...args: unknown[]) => void,

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -60,9 +60,7 @@ await Promise.all(
 )
 
 // Courtesy cleanup: builds predating the `.homeybuild` emission left
-// bundles in the source tree. The CLI would copy them into the package,
-// where this build immediately overwrites them — harmless, but they
-// linger confusingly in the working tree.
+// bundles in the source tree, where they linger confusingly.
 await Promise.all(
   entryPoints.flatMap((entryPoint) =>
     ['.js', '.mjs'].map(async (extension) =>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -169,9 +169,9 @@ const alertError = async (
   }
 }
 
-// The one sanctioned fire-and-forget seam (the lib's shape): detach
-// already-started work from an event handler, alerting a rejection
-// instead of propagating it.
+// The one sanctioned fire-and-forget seam: detach already-started
+// work from an event handler, alerting a rejection instead of
+// propagating it.
 const fireAndForget = (
   homey: HomeySettings,
   promise: Promise<unknown>,
@@ -488,8 +488,8 @@ const generateCommonSettings = (
 }
 
 // The credentials section folds once signed in; the device settings
-// stay hidden until then (mirrors melcloud's #content gating), so a
-// signed-out page shows only the expanded credentials.
+// stay hidden until then, so a signed-out page shows only the
+// expanded credentials.
 const setAuthenticatedState = (
   elements: PageElements,
   isAuthenticated: boolean,

--- a/tests/mock-device-class.ts
+++ b/tests/mock-device-class.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest'
 
-// Options for createMockDeviceClass.
 // - `overrides`: instance-level props assigned in the constructor (shallow merge).
 // - `superMocks`: prototype-level methods that delegate to the provided vi.fn.
 //   Required for every method HeatzyDevice overrides with a super call


### PR DESCRIPTION
Family-wide comment pass (adversarially reviewed proposal by proposal): drops reviewer narration, debate relics, version/library provenance and restatements of adjacent code; trims verbose blocks to their load-bearing constraint; fixes (partially) obsolete comments. On-device evidence, config triage-ledger reasons and lint-required JSDoc untouched. **No code changes** — 6 files changed, 11 insertions(+), 16 deletions(-). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)