### PR TITLE
refactor: harmonize the app-API surface (shared transport, updateDeviceSettings)

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -28,7 +28,7 @@
       "method": "POST",
       "path": "/boot-error"
     },
-    "setDeviceSettings": {
+    "updateDeviceSettings": {
       "method": "PUT",
       "path": "/settings/devices"
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,15 @@ coverage.
   SDK gaps and app-specific design — Homey injects its own class-based
   stylesheet at runtime, which is not in the repo and not available
   offline.
+- App-API surface conventions (aligned on com.melcloud): paths are
+  kebab-case REST, `get*` for GET and `update*` for PUT (never `set*`),
+  breadcrumbs log the verbed form (`'GET /settings/devices'`). Handler
+  renames are wire-invisible (routing is method+path).
+  `settings/callback-api.mts` is the settings page's transport (the
+  settings SDK is error-first-callback); it is a byte-identical copy of
+  com.melcloud's (com.melcloud.extension carries the third) — edit all
+  three together. `fireAndForget` stays local by design: it binds
+  `homey` to auto-alert, this page's error policy.
 - Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
   settings Apply/Refresh pair — never re-derive its invariant at a call
   site. Its `serialize` must stay a PURE form snapshot, never a

--- a/api.mts
+++ b/api.mts
@@ -40,7 +40,7 @@ const api = {
     }
   },
   getDeviceSettings: ({ homey }: { homey: Homey }): DeviceSettings => {
-    logSettingsRoute(homey.app, '/settings/devices')
+    logSettingsRoute(homey.app, 'GET /settings/devices')
     return homey.app.getDeviceSettings()
   },
   getDriverSettings: ({
@@ -48,11 +48,11 @@ const api = {
   }: {
     homey: Homey
   }): Partial<Record<string, DriverSetting[]>> => {
-    logSettingsRoute(homey.app, '/settings/drivers')
+    logSettingsRoute(homey.app, 'GET /settings/drivers')
     return homey.app.getDriverSettings()
   },
   getLanguage: ({ homey }: { homey: Homey }): string => {
-    logSettingsRoute(homey.app, '/language')
+    logSettingsRoute(homey.app, 'GET /language')
     return homey.i18n.getLanguage()
   },
   isAuthenticated: ({ homey }: { homey: Homey }): boolean => {
@@ -78,7 +78,7 @@ const api = {
   }): void => {
     homey.app.error('Settings webview boot failure:', body)
   },
-  setDeviceSettings: async ({
+  updateDeviceSettings: async ({
     body,
     homey,
   }: {
@@ -86,7 +86,7 @@ const api = {
     homey: Homey
   }): Promise<void> => {
     logSettingsRoute(homey.app, 'PUT /settings/devices')
-    await homey.app.setDeviceSettings(body)
+    await homey.app.updateDeviceSettings(body)
   },
 }
 

--- a/app.json
+++ b/app.json
@@ -29,7 +29,7 @@
       "method": "POST",
       "path": "/boot-error"
     },
-    "setDeviceSettings": {
+    "updateDeviceSettings": {
       "method": "PUT",
       "path": "/settings/devices"
     }

--- a/app.mts
+++ b/app.mts
@@ -200,7 +200,7 @@ export default class HeatzyApp extends App {
     return this.#facadeManager.get(instance)
   }
 
-  public async setDeviceSettings(settings: Settings): Promise<void> {
+  public async updateDeviceSettings(settings: Settings): Promise<void> {
     await Promise.all(
       this.#getDevices().map(async (device) => {
         const changedKeys = Object.keys(settings).filter(

--- a/settings/callback-api.mts
+++ b/settings/callback-api.mts
@@ -1,0 +1,58 @@
+import type Homey from 'homey/lib/HomeySettings'
+
+// The settings SDK's `homey.api`/`homey.confirm` are error-first
+// callbacks (unlike the widget SDK's promise-returning `homey.api`), so
+// the settings pages share one promisification primitive and per-verb
+// wrappers over it. Byte-identical copies of this module live in the
+// sibling Homey apps — edit them together.
+export const homeyCallback = async <T,>(
+  call: (callback: (error: Error | null, result: T) => void) => void,
+): Promise<T> =>
+  new Promise((resolve, reject) => {
+    call((error, result) => {
+      if (error !== null) {
+        reject(error)
+        return
+      }
+      resolve(result)
+    })
+  })
+
+export const homeyApiDelete = async (
+  homey: Homey,
+  path: string,
+): Promise<void> =>
+  homeyCallback((callback) => {
+    homey.api('DELETE', path, callback)
+  })
+
+export const homeyApiGet = async <T,>(homey: Homey, path: string): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('GET', path, callback)
+  })
+
+export const homeyApiPost = async <T,>(
+  homey: Homey,
+  path: string,
+  body: unknown,
+): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('POST', path, body, callback)
+  })
+
+export const homeyApiPut = async <T,>(
+  homey: Homey,
+  path: string,
+  body: unknown,
+): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('PUT', path, body, callback)
+  })
+
+export const homeyConfirm = async (
+  homey: Homey,
+  message: string,
+): Promise<boolean> =>
+  homeyCallback((callback) => {
+    homey.confirm(message, null, callback)
+  })

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -4,6 +4,13 @@ import type HomeySettings from 'homey/lib/HomeySettings'
 import type { DeviceSettings, Settings } from '../types/device-settings.mts'
 import type { DriverSetting } from '../types/driver-settings.mts'
 import { getErrorMessage } from '../lib/get-error-message.mts'
+import {
+  homeyApiDelete,
+  homeyApiGet,
+  homeyApiPost,
+  homeyApiPut,
+  homeyConfirm,
+} from './callback-api.mts'
 import { type DirtyGate, createDirtyGate } from './dirty-gate.mts'
 
 // Runtime floor: esbuild lowers syntax to es2020, but runtime APIs must
@@ -85,78 +92,6 @@ const getPageElements = (): PageElements => ({
   resetCredentials: getElement('reset_credentials', HTMLButtonElement),
   settingsCommon: getElement('settings_common', HTMLDivElement),
 })
-
-const homeyApiGet = async <T,>(
-  homey: HomeySettings,
-  path: string,
-): Promise<T> =>
-  new Promise((resolve, reject) => {
-    homey.api('GET', path, (error: Error | null, result: T) => {
-      if (error === null) {
-        resolve(result)
-        return
-      }
-      reject(error)
-    })
-  })
-
-const homeyApiDelete = async (
-  homey: HomeySettings,
-  path: string,
-): Promise<void> =>
-  new Promise((resolve, reject) => {
-    homey.api('DELETE', path, (error: Error | null) => {
-      if (error === null) {
-        resolve()
-        return
-      }
-      reject(error)
-    })
-  })
-
-const homeyApiPost = async (
-  homey: HomeySettings,
-  path: string,
-  body: unknown,
-): Promise<void> =>
-  new Promise((resolve, reject) => {
-    homey.api('POST', path, body, (error: Error | null) => {
-      if (error === null) {
-        resolve()
-        return
-      }
-      reject(error)
-    })
-  })
-
-const homeyApiPut = async (
-  homey: HomeySettings,
-  path: string,
-  body: unknown,
-): Promise<void> =>
-  new Promise((resolve, reject) => {
-    homey.api('PUT', path, body, (error: Error | null) => {
-      if (error === null) {
-        resolve()
-        return
-      }
-      reject(error)
-    })
-  })
-
-const homeyConfirm = async (
-  homey: HomeySettings,
-  message: string,
-): Promise<boolean> =>
-  new Promise((resolve) => {
-    homey.confirm(
-      message,
-      null,
-      (error: Error | null, isConfirmed: boolean) => {
-        resolve(error === null && isConfirmed)
-      },
-    )
-  })
 
 const alertError = async (
   homey: HomeySettings,

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -25,7 +25,7 @@ const mockApp = {
   getDeviceSettings: vi.fn<() => DeviceSettings>(),
   getDriverSettings: vi.fn<() => Partial<Record<string, DriverSetting[]>>>(),
   log: vi.fn<(...args: readonly unknown[]) => void>(),
-  setDeviceSettings: vi.fn<(settings: Settings) => Promise<void>>(),
+  updateDeviceSettings: vi.fn<(settings: Settings) => Promise<void>>(),
 }
 
 const mockI18n = { getLanguage: vi.fn<() => string>() }
@@ -98,7 +98,7 @@ describe('api', () => {
       expect(mockApp.getDeviceSettings).toHaveBeenCalledTimes(1)
       expect(mockApp.log).toHaveBeenCalledWith({
         dataType: SETTINGS_PAGE,
-        route: '/settings/devices',
+        route: 'GET /settings/devices',
       })
     })
   })
@@ -114,7 +114,7 @@ describe('api', () => {
       expect(mockApp.getDriverSettings).toHaveBeenCalledTimes(1)
       expect(mockApp.log).toHaveBeenCalledWith({
         dataType: SETTINGS_PAGE,
-        route: '/settings/drivers',
+        route: 'GET /settings/drivers',
       })
     })
   })
@@ -131,7 +131,7 @@ describe('api', () => {
         expect(mockI18n.getLanguage).toHaveBeenCalledTimes(1)
         expect(mockApp.log).toHaveBeenCalledWith({
           dataType: SETTINGS_PAGE,
-          route: '/language',
+          route: 'GET /language',
         })
       },
     )
@@ -168,13 +168,13 @@ describe('api', () => {
   })
 
   describe('device settings update', () => {
-    it('should delegate to app.setDeviceSettings and log the breadcrumb', async () => {
+    it('should delegate to app.updateDeviceSettings and log the breadcrumb', async () => {
       const body = mock<Settings>({ always_on: true })
-      mockApp.setDeviceSettings.mockResolvedValue()
+      mockApp.updateDeviceSettings.mockResolvedValue()
 
-      await api.setDeviceSettings({ body, homey })
+      await api.updateDeviceSettings({ body, homey })
 
-      expect(mockApp.setDeviceSettings).toHaveBeenCalledWith(body)
+      expect(mockApp.updateDeviceSettings).toHaveBeenCalledWith(body)
       expect(mockApp.log).toHaveBeenCalledWith({
         dataType: SETTINGS_PAGE,
         route: 'PUT /settings/devices',

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -691,7 +691,7 @@ describe(HeatzyApp, () => {
       ])
       await app.onInit()
 
-      await app.setDeviceSettings(mock<Settings>({ always_on: true }))
+      await app.updateDeviceSettings(mock<Settings>({ always_on: true }))
 
       expect(setSettings).toHaveBeenCalledWith({ always_on: true })
       expect(onSettings).toHaveBeenCalledTimes(1)
@@ -710,7 +710,7 @@ describe(HeatzyApp, () => {
       ])
       await app.onInit()
 
-      await app.setDeviceSettings(mock<Settings>({ always_on: true }))
+      await app.updateDeviceSettings(mock<Settings>({ always_on: true }))
 
       expect(setSettings).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
Part of the family-wide API-surface harmonization (sibling PRs on com.melcloud and com.melcloud.extension).

- **`settings/callback-api.mts`** — byte-identical tri-repo transport module (`homeyCallback` + generic `homeyApiGet/Post/Put/Delete` + `homeyConfirm`) replacing five hand-inlined Promise executors.
- **`updateDeviceSettings`** — the `PUT /settings/devices` chain renamed end to end (handler id, app method, tests): PUT ⇒ `update*`, never `set*`. Wire-invisible (routing is method+path).
- **Breadcrumbs** — verbed form uniformly (`'GET /settings/devices'`).
- `fireAndForget` stays local by design (binds `homey` to auto-alert — this page's error policy), documented in CLAUDE.md.

Full suite green (167 tests). No wire-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)