### PR TITLE
chore: release 23.0.3

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -86,5 +86,9 @@
   "23.0.2": {
     "en": "Settings: the Update button now stays greyed out until you change a setting.",
     "fr": "Réglages : le bouton Mettre à jour reste désormais grisé tant que vous n'avez pas modifié un réglage."
+  },
+  "23.0.3": {
+    "en": "Under-the-hood maintenance and hardening.",
+    "fr": "Maintenance interne et durcissement."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -91,5 +91,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.2"
+  "version": "23.0.3"
 }

--- a/app.json
+++ b/app.json
@@ -92,7 +92,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.2",
+  "version": "23.0.3",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.2",
+  "version": "23.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.0.2",
+      "version": "23.0.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.2",
+  "version": "23.0.3",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {


### PR DESCRIPTION
Release **23.0.3** — maintenance only (shared API transport, `updateDeviceSettings` rename, API-surface test pins, comment cleanup). Version bump + changelog (en/fr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)