### PR TITLE
fix: swap the deviceNotFound translations back to their locales

### DIFF
--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "deviceNotFound": "Appareil introuvable."
+    "deviceNotFound": "Device not found."
   },
   "notifications": {
     "sessionExpired": "Your Heatzy session has expired: please sign in again from the app settings.",

--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "deviceNotFound": "Device not found."
+    "deviceNotFound": "Appareil introuvable."
   },
   "notifications": {
     "sessionExpired": "Votre session Heatzy a expiré : reconnectez-vous depuis les réglages de l’application.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "deviceNotFound": "Appareil introuvable."
+    "deviceNotFound": "Device not found."
   },
   "settings": {
     "authenticate": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "deviceNotFound": "Device not found."
+    "deviceNotFound": "Appareil introuvable."
   },
   "settings": {
     "authenticate": {


### PR DESCRIPTION
Store review flagged inconsistent translations: `locales/en.json` carried the French text ("Appareil introuvable.") while `locales/fr.json` carried the English one ("Device not found."). Only this key was crossed — every other string is in its own language. Fixed at the `.homeycompose/locales` source and the CLI-regenerated runtime files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)