### PR TITLE
style: drop the bespoke export-type lint rule for documented doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,14 @@ coverage.
   one means extract/refactor, not bump.
 - Class members sort alphabetically (perfectionist), fields before
   methods, public before private. Increments use prefix `++`/`--`.
+- All-type exports hoist the keyword (`export type { A, B }`); mixed
+  exports keep inline `type` specifiers, mirroring the
+  inline-type-imports style. No shipped rule enforces the export side
+  (`consistent-type-exports` tolerates inline specifiers once present;
+  `import-x/consistent-type-specifier-style` covers imports only): the
+  convention is maintained by hand, in review — a bespoke
+  `no-restricted-syntax` selector for it was removed by decision
+  (2026-07-28).
 - Comments state intent or a constraint the code cannot show — never
   history ("was X before"), narration, or the library something came from.
 - Beware `no-unnecessary-condition` vs TypeScript's control-flow

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -512,18 +512,6 @@ const config = defineConfig([
       'no-object-constructor': 'error',
       'no-param-reassign': 'error',
       'no-promise-executor-return': 'error',
-      // `consistent-type-exports` tolerates inline specifiers on all-type
-      // exports; no shipped rule hoists them, so the constraint is spelled
-      // out here (imports get the same via `consistent-type-imports`).
-      'no-restricted-syntax': [
-        'error',
-        {
-          message:
-            'An all-type export hoists the keyword: `export type { … }`.',
-          selector:
-            "ExportNamedDeclaration[exportKind='value']:has(ExportSpecifier[exportKind='type']):not(:has(ExportSpecifier[exportKind='value']))",
-        },
-      ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
       'no-sequences': [


### PR DESCRIPTION
Replaces the `no-restricted-syntax` selector merged earlier (which forced `export type { … }` hoisting) with documented doctrine in CLAUDE.md, per owner decision: the convention — all-type exports hoist the keyword, mixed exports keep inline specifiers — is maintained by hand, in review. The codebase already complies (no inline `type` export specifiers exist), and the full suite (format, lint, typecheck, tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)