### PR TITLE
chore(release): 23.0.4

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -90,5 +90,9 @@
   "23.0.3": {
     "en": "Under-the-hood maintenance and hardening.",
     "fr": "Maintenance interne et durcissement."
+  },
+  "23.0.4": {
+    "en": "The message shown when a device cannot be found now appears in the right language.",
+    "fr": "Le message indiquant qu'un appareil est introuvable s'affiche désormais dans la bonne langue."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -91,5 +91,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.3"
+  "version": "23.0.4"
 }

--- a/app.json
+++ b/app.json
@@ -92,7 +92,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.3",
+  "version": "23.0.4",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.3",
+  "version": "23.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.0.3",
+      "version": "23.0.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.3",
+  "version": "23.0.4",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {


### PR DESCRIPTION
Version bump shipping the `deviceNotFound` translation fix the store review flagged (the English locale carried the French text and vice versa; fixed in #1042).

- `.homeychangelog.json`: new `23.0.4` entry (`en` + `fr`, this app's 2 locales).
- `version` bumped in `.homeycompose/app.json`, `package.json`/`package-lock.json` aligned via `npm version`.
- `app.json` regenerated by `homey app validate --level=publish` (committed verbatim).

Full suite green locally: `format:fix`, `lint`, `typecheck`, `test` (178 passing), `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)