### PR TITLE
test: drop the per-id sweep the key equality already subsumes

### DIFF
--- a/tests/unit/api-contract.test.ts
+++ b/tests/unit/api-contract.test.ts
@@ -6,14 +6,12 @@ import api from '../../api.mts'
 const sortedKeys = (object: object): string[] =>
   Object.keys(object).toSorted((left, right) => left.localeCompare(right))
 
+// One equality pins the ids <-> handlers mapping in both directions at
+// once: a handler with no declaration and a declaration with no handler
+// both break it, and the diff names the offender. A per-id existence
+// sweep alongside it could only ever fail together with the equality,
+// so it is not kept.
 describe('api contract', () => {
-  it.each(Object.keys(appConfig.api))(
-    '%s handler exists in api.mts',
-    (name) => {
-      expect(api).toHaveProperty(name)
-    },
-  )
-
   // The compile-time half of the contract, asserted on the whole union
   // at once: no per-name method reference ever leaves its object
   // (unbound-method).
@@ -21,7 +19,7 @@ describe('api contract', () => {
     expectTypeOf<(typeof api)[keyof typeof api]>().toBeFunction()
   })
 
-  it('should not have handlers missing from app.json', () => {
+  it('should declare exactly the handlers app.json names', () => {
     expect(sortedKeys(api)).toStrictEqual(sortedKeys(appConfig.api))
   })
 })


### PR DESCRIPTION
## What

Removes the per-id existence sweep from `api-contract.test.ts`.

## Why

`it.each(Object.keys(appConfig.api))` asserting `toHaveProperty(name)` can only ever fail together with the `toStrictEqual(sortedKeys(...))` beside it: strict key equality already implies every declared name exists as a handler, in both directions, and its diff names the offender. The generated cases bought no coverage.

Found while reviewing the contract tests across the five repos; the same removal lands in `com.melcloud` and `com.melcloud.extension`.

## Note on the route guard

Nothing needed here. This app's guard already asserts that every `homeyApi*` call site yields a `(method, path)` pair — the completeness invariant that makes an unread call a failure instead of a silent pass. Reviewing the family showed it to be the strongest of the three, and it is being adopted by the two siblings rather than changed here: `com.melcloud` was counting one call per surface (which let two builder-written call sites go unread), and `com.melcloud.extension` had no method check at all.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (172 tests, coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level