### PR TITLE
test: pin the settings key union against what the library writes

### DIFF
--- a/tests/unit/app-settings-contract.test.ts
+++ b/tests/unit/app-settings-contract.test.ts
@@ -1,0 +1,21 @@
+import type { HeatzyAPISettings } from '@olivierzal/heatzy-api'
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { HomeySettings } from '../../types/app-settings.mts'
+
+// The app hand-maintains HomeySettings while heatzy-api owns the key
+// names its SettingManager writes, so the union drifts silently — that
+// is how com.melcloud ended up persisting loginBackoffUntil for
+// releases without declaring it. This fails at typecheck the day a
+// release adds a @setting accessor.
+//
+// One-way on purpose: HomeySettings legitimately carries the app's own
+// notifiedVersion, which the library knows nothing about. And no
+// prefixing to model here, unlike com.melcloud — this app drives a
+// single dialect, so #createSettingManager passes keys through
+// untouched.
+describe('app settings contract', () => {
+  it('should declare every key the library can write', () => {
+    expectTypeOf<keyof HeatzyAPISettings>().toExtend<keyof HomeySettings>()
+  })
+})


### PR DESCRIPTION
## What

Adds the settings-contract guard com.melcloud gained in OlivierZal/com.melcloud#1500, adapted to this app.

## Why

`types/app-settings.mts` is hand-maintained while heatzy-api owns the key names its `SettingManager` writes — the exact setup that let com.melcloud persist `loginBackoffUntil` (and `homeLoginBackoffUntil`) for releases without declaring either.

**This app's union is correct today** — verified against the five `@setting` accessors in `heatzy-api/src/api/heatzy.ts` (`expiry`, `loginBackoffUntil`, `password`, `token`, `username`) plus the app's own `notifiedVersion`. Nothing was keeping it that way.

heatzy-api already exports `HeatzyAPISettings`, so the guard is one assertion:

```ts
expectTypeOf<keyof HeatzyAPISettings>().toExtend<keyof HomeySettings>()
```

Simpler than com.melcloud's, which needs `Capitalize` to model its `home` prefix: this app drives a single dialect and `#createSettingManager` passes keys through untouched.

One-way on purpose — `HomeySettings` legitimately carries `notifiedVersion`, which the library knows nothing about.

## Verification

**Mutation-tested**: dropping `loginBackoffUntil` from the union fails `npm run typecheck` and the error names the missing key. Note it does *not* fail `vitest run` alone — `expectTypeOf` is erased at runtime — so `typecheck` is the gate, and it is already a required check.

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level

Tests only: no changelog entry, no version bump.