### PR TITLE
test: type the dirty-gate button doubles instead of asserting them

### DIFF
--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DeviceSettings, Settings } from '../../types/device-settings.mts'
 import type { DriverSetting } from '../../types/driver-settings.mts'
-import { mock } from '../helpers.js'
+import { mock } from '../helpers.ts'
 
 const { default: api } = await import('../../api.mts')
 

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createDirtyGate } from '../../settings/dirty-gate.mts'
+import { mock } from '../helpers.ts'
 
 // The gate is headless: buttons only need a `disabled` slot, and wired
 // targets only need to dispatch events, so plain doubles are enough.
@@ -10,8 +11,8 @@ const setup = (): {
   gate: ReturnType<typeof createDirtyGate>
   refreshElement: HTMLButtonElement
 } => {
-  const applyElement = { disabled: false } as unknown as HTMLButtonElement
-  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const applyElement = mock<HTMLButtonElement>({ disabled: false })
+  const refreshElement = mock<HTMLButtonElement>({ disabled: false })
   const form = { value: 'pristine' }
   const gate = createDirtyGate({
     applyElement,


### PR DESCRIPTION
## What

The two headless button doubles in `tests/unit/dirty-gate.test.ts` go through the typed `mock<T>()` factory this repo already has, instead of a double assertion:

```diff
-  const applyElement = { disabled: false } as unknown as HTMLButtonElement
-  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const applyElement = mock<HTMLButtonElement>({ disabled: false })
+  const refreshElement = mock<HTMLButtonElement>({ disabled: false })
```

Companion to OlivierZal/com.melcloud#1504, which carries this test one import line apart — edited together, as the family requires.

## Why

Measured on the com.melcloud twin rather than assumed. Three candidate forms, two mutations:

| mutation | `as unknown as T` | `cast(...)` | `mock<T>({...})` |
|---|---|---|---|
| a key absent from the target type | not caught | not caught | **TS2353** |
| a wrong declared return type | TS2322 | not caught | **TS2322** |

The factory is strictly better than both: it keeps the assignability check *and* adds key checking, with no `as unknown as`, no `never`, and no disable. (`cast` — which an earlier audit item proposed adopting here — is the weakest of the three, so it stays out of this repo.)

## What is left alone

`heatzy-driver.test.ts:79` re-types a constructor: `HeatzyDriver as unknown as new () => HeatzyDriver`. `new` on an abstract constructor is forbidden by design, so no non-assertion form exists. Same for `mock-device-class.ts:88`, which additionally cannot import from `helpers.ts` — `helpers.ts` re-exports *from it*.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level

Tests only, no source change.