### PR TITLE
refactor: drop two types left over from the com.melcloud rewrite

### DIFF
--- a/types/device-settings.mts
+++ b/types/device-settings.mts
@@ -1,10 +1,10 @@
 import type { PreviousMode } from '@olivierzal/heatzy-api'
 
-export type DeviceSetting = Record<string, unknown>
+type DeviceSetting = Record<string, unknown>
+
+type OnMode = 'previous' | PreviousMode
 
 export type DeviceSettings = Record<string, DeviceSetting>
-
-export type OnMode = 'previous' | PreviousMode
 
 export interface Settings extends Partial<Record<string, unknown>> {
   readonly always_on?: boolean

--- a/types/driver-settings.mts
+++ b/types/driver-settings.mts
@@ -1,14 +1,6 @@
-import type { LoginCredentials } from '@olivierzal/heatzy-api'
-
 interface DriverSettingValue {
   readonly id: string
   readonly label: string
-}
-
-export interface DriverCapabilitiesOptions {
-  readonly title: string
-  readonly type: string
-  readonly values?: readonly DriverSettingValue[] | undefined
 }
 
 export interface DriverSetting {
@@ -24,8 +16,4 @@ export interface DriverSetting {
   readonly placeholder?: string
   readonly units?: string | undefined
   readonly values?: readonly DriverSettingValue[] | undefined
-}
-
-export interface LoginDriverSetting extends DriverSetting {
-  readonly id: keyof LoginCredentials
 }

--- a/types/manifest.mts
+++ b/types/manifest.mts
@@ -1,5 +1,28 @@
 import type { LocalizedStrings } from './bases.mts'
 
+interface ManifestDriverSetting {
+  readonly label: LocalizedStrings
+  readonly children?: readonly ManifestDriverSettingData[]
+  readonly id?: string
+}
+
+interface ManifestDriverSettingData {
+  readonly id: string
+  readonly label: LocalizedStrings
+  readonly type: string
+  readonly max?: number
+  readonly min?: number
+  readonly units?: string
+  readonly values?: readonly {
+    readonly id: string
+    readonly label: LocalizedStrings
+  }[]
+}
+
+interface PairSetting {
+  readonly id: string
+}
+
 export interface LoginSetting extends PairSetting {
   readonly id: 'login'
   readonly options: {
@@ -25,27 +48,4 @@ export interface ManifestDriver {
   readonly name: LocalizedStrings
   readonly pair?: readonly PairSetting[]
   readonly settings?: readonly ManifestDriverSetting[]
-}
-
-export interface ManifestDriverSetting {
-  readonly label: LocalizedStrings
-  readonly children?: readonly ManifestDriverSettingData[]
-  readonly id?: string
-}
-
-export interface ManifestDriverSettingData {
-  readonly id: string
-  readonly label: LocalizedStrings
-  readonly type: string
-  readonly max?: number
-  readonly min?: number
-  readonly units?: string
-  readonly values?: readonly {
-    readonly id: string
-    readonly label: LocalizedStrings
-  }[]
-}
-
-export interface PairSetting {
-  readonly id: string
 }


### PR DESCRIPTION
## What

- **Deletes** two interfaces referenced nowhere at all.
- **Un-exports** five types used only inside their declaring file.

## The two dead ones have a traceable origin

`DriverCapabilitiesOptions` and `LoginDriverSetting` in `types/driver-settings.mts` are each mentioned exactly once — their own declaration. Not in sources, not in tests, not even within their own file.

com.melcloud uses them **13** and **3** times. That is what they are: types copied wholesale by the 23.0.0 rewrite on the com.melcloud reference (#1022), which this app never needed. Genuine leftovers, not a shape kept for symmetry.

## The five un-exports

`DeviceSetting`, `OnMode`, `ManifestDriverSetting`, `ManifestDriverSettingData`, `PairSetting` are all consumed inside their own file (e.g. `DeviceSettings = Record<string, DeviceSetting>`, `LoginSetting extends PairSetting`). They stay — only the `export` keyword goes, since nothing outside needs to name them.

## What is *not* dead, despite looking it

The scan also flagged `DirtyGateOptions` and `homeyCallback`. Both are **kept**: `settings/dirty-gate.mts` and `settings/callback-api.mts` are byte-identical across com.melcloud, com.heatzy and com.melcloud.extension — verified with `diff` — and every export is used in at least one of the three. `homeyCallback` is used in com.melcloud and the extension, just not here. Editing them apart would break the invariant CLAUDE.md mandates.

Companion sweeps: OlivierZal/com.melcloud#1507, OlivierZal/melcloud-api#1659, OlivierZal/heatzy-api#1160. com.melcloud.extension needed nothing — all five of its flagged exports were shared-kernel.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level