### PR TITLE
fix: take heatzy-api 11.0.0 so a failed sync is not a silent empty account

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -94,5 +94,9 @@
   "23.0.4": {
     "en": "The message shown when a device cannot be found now appears in the right language.",
     "fr": "Le message indiquant qu'un appareil est introuvable s'affiche désormais dans la bonne langue."
+  },
+  "23.1.0": {
+    "en": "Signing in no longer reports success when your devices could not be loaded: instead of an empty device list, the app now tells you what went wrong.",
+    "fr": "La connexion ne s'annonce plus réussie lorsque vos appareils n'ont pas pu être chargés : au lieu d'une liste vide, l'app vous indique désormais ce qui a échoué."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -91,5 +91,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.4"
+  "version": "23.1.0"
 }

--- a/app.json
+++ b/app.json
@@ -92,7 +92,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.0.4",
+  "version": "23.1.0",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.4",
+  "version": "23.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.0.4",
+      "version": "23.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/heatzy-api": "^10.0.0",
+        "@olivierzal/heatzy-api": "11.0.0",
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@olivierzal/heatzy-api": {
-      "version": "10.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/10.0.0/70849fe7dc5d611eb223a3fc092cc7a96d5fca5e",
-      "integrity": "sha512-6RNcLuLtbcO1S5lpdxAWaH/jkeVJ1Lg5gAnlzeNrBQFEGwlCSYVFhRhaEMsYD7i9Tv1mseBE0jgl03zOuAE5fQ==",
+      "version": "11.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/11.0.0/c3a039d2bf886e3176d2a62f625dfe38d32a5eff",
+      "integrity": "sha512-+japTkOnwdWUvq0BpK1KVa0u8/eOuRTYmSz0pqo3sLnmEKHF0IfQlublr+POpTjZmfkBBGHdVMs7T3x2OrswYg==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.0.4",
+  "version": "23.1.0",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/heatzy-api": "^10.0.0",
+    "@olivierzal/heatzy-api": "11.0.0",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Bumps `@olivierzal/heatzy-api` from `^10.0.0` (resolving 10.0.0) to an exact `11.0.0`, and releases it as **23.1.0**.

## Why this was missed

heatzy-api published 11.0.0 on **2026-07-29**. This app declared `^10.0.0` — a caret that **can never accept 11.x** — and no bump PR has ever existed in this repo (checked across the last 100 PRs). By contrast com.melcloud adopts melcloud-api by hand every time (#1498, #1495, #1485, #1437, #1426).

So the fix has been sitting published and undelivered.

## What the fix does, in user terms

From heatzy-api's 11.0.0 changelog:

> `authenticate()` now rejects when its enforced post-auth sync fails. Its documented guarantee — "successful return guarantees the registry reflects server state" — was void: the enforced sync ran through `fetch()`, whose catch-all logs and returns an empty list. A `ValidationError`, an unknown `product_key` […] or any registry error therefore resolved as a successful sign-in over an empty registry, **which downstream reads as "this account has no devices"**.

That is a symptom users actually report, on correct credentials.

## Adoption needed no source change

Both call sites already separate `AuthenticationError` from everything else — which is precisely the shape 11.0.0 expects:

| site | non-`AuthenticationError` handling |
|---|---|
| `api.mts:15` | `getErrorMessage(error)` → the real cause reaches the settings webview |
| `drivers/heatzy/driver.mts:241` | rethrown → surfaces in the pairing dialog |

`npm run typecheck` passes with **zero** source edits.

## Exact pin, not a caret

The caret is what held this app back silently. Pinning exactly matches com.melcloud's policy for `@olivierzal/*` and makes every future adoption an explicit, reviewable act.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes — 174 tests, 100%
- [x] `npm run homey:validate` passes at `publish` level
- [x] `npm audit --omit=dev` → 0 vulnerabilities
- [x] Changelog entry in this repo's `en`/`fr` policy; `package.json` = `.homeycompose/app.json` = `app.json` = changelog key = 23.1.0