### PR TITLE
fix: close the build-script lint gap by making the scripts TypeScript

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,19 @@ caught real failures that the others miss:
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7).
 - `npm test` / `npm run test:coverage` — vitest; branches are at 100%,
   keep them there.
-- `npm run build` — esbuild bundle (`scripts/bundle.mjs`) + `tsc`
+- `npm run build` — esbuild bundle (`scripts/bundle.mts`) + `tsc`
   emit, BOTH into `.homeybuild`. The Homey CLI runs `npm run build`
   when it detects TypeScript (`devDependencies.typescript`; it
   validates `outDir: .homeybuild`) — but only AFTER its pre-process
   copy into `.homeybuild`, so the source tree stays sources-only and
   everything the package needs must be emitted there: tsc does it via
-  `outDir`, and `bundle.mjs` emits the settings webview bundles there
+  `outDir`, and `bundle.mts` emits the settings webview bundles there
   too (source-tree outfiles would land too late to be copied, and a
   store install would 404 the bundles). The CLI's own build invocation
   is therefore sufficient for install, run, validate and publish alike;
   a standalone suite run (no `.homeybuild` page copy) still proves the
   bundles compile.
-- Cache-busting `?v=` — a PACKAGE-TIME transform: `bundle.mjs` stamps
+- Cache-busting `?v=` — a PACKAGE-TIME transform: `bundle.mts` stamps
   every local asset reference of the `.homeybuild` page copy with a
   content hash (`?v=<hash>`), so phone webviews (which cache assets
   across app versions) refetch an asset exactly when its bytes change.
@@ -110,7 +110,7 @@ coverage.
   mechanism without new on-device evidence: classic `defer` is the
   cold-verified form.
 - Phone webviews also cache the HTML ITSELF across app versions, so
-  shipped bundle filenames are a COMPAT CONTRACT: `scripts/bundle.mjs`
+  shipped bundle filenames are a COMPAT CONTRACT: `scripts/bundle.mts`
   builds the settings entry twice — `index.js` (IIFE) for the current
   HTML, plus an `index.mjs` twin for every cached older HTML. Heatzy
   divergence from com.melcloud: the cached-HTML era here loaded

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run homey:start  # run the app on your Homey (remote)
 Architecture notes:
 
 - The API layer lives in [@olivierzal/heatzy-api](https://github.com/OlivierZal/heatzy-api), a sibling repository with its own tooling; API bugs are fixed there, not worked around here.
-- Browser code (the `settings/` page) is bundled by `scripts/bundle.mjs` into self-contained bundles; the outputs are emitted into `.homeybuild` by `npm run build`, which the Homey CLI runs automatically on validate/publish.
+- Browser code (the `settings/` page) is bundled by `scripts/bundle.mts` into self-contained bundles; the outputs are emitted into `.homeybuild` by `npm run build`, which the Homey CLI runs automatically on validate/publish.
 - Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint) until TypeScript 7.1 ships its stable programmatic API.
 - Test coverage is enforced at 100% for backend code; browser glue (`settings/`) is excluded from coverage, so the badge covers the driver, app and API layers only.
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -54,7 +54,7 @@ const config: Config[] = defineConfig([
     ignores: [
       '.homeybuild/',
       'coverage/',
-      // esbuild outputs (see scripts/bundle.mjs), also gitignored
+      // esbuild outputs (see scripts/bundle.mts), also gitignored
       'settings/index.mjs',
     ],
   },
@@ -427,7 +427,12 @@ const config: Config[] = defineConfig([
           bundledDependencies: false,
           // The settings webview source is bundled by esbuild, so its
           // imports may live in devDependencies.
-          devDependencies: ['*.config.ts', 'settings/**', 'tests/**'],
+          devDependencies: [
+            '*.config.ts',
+            'scripts/**',
+            'settings/**',
+            'tests/**',
+          ],
           optionalDependencies: false,
           peerDependencies: false,
         },
@@ -997,7 +1002,7 @@ const config: Config[] = defineConfig([
       'unicorn/no-invalid-file-input-accept': 'error',
       // The referenced module bundles are gitignored build outputs (CI
       // lints without building); their existence is guaranteed harder by
-      // scripts/bundle.mjs, which hashes every local reference and
+      // scripts/bundle.mts, which hashes every local reference and
       // throws when one is missing.
       'unicorn/no-missing-local-resource': 'off',
       'unicorn/text-encoding-identifier-case': 'error',
@@ -1219,7 +1224,11 @@ const config: Config[] = defineConfig([
     },
   },
   {
+    // Scoped: without `files`, this block applied to every file, which
+    // made it the only one reaching `**/*.mjs` — and leaked 28 inert
+    // `yml/*` rules onto every `.mts` as well.
     extends: [ymlConfigs.standard, ymlConfigs.prettier],
+    files: ['**/*.{yaml,yml}'],
     rules: {
       'yml/file-extension': [
         'error',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "scripts": {
     "build": "npm run build:assets && node ./node_modules/@typescript/native/bin/tsc --project tsconfig.build.json",
-    "build:assets": "node scripts/bundle.mjs",
+    "build:assets": "node scripts/bundle.mts",
     "format": "prettier . --check",
     "format:fix": "prettier . --write",
     "github:push": "npm run homey:validate && npm run lint:fix && npm run format:fix && git push",

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -7,7 +7,7 @@ import { createHash } from 'node:crypto'
 import { readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { build } from 'esbuild'
+import { type BuildOptions, build } from 'esbuild'
 
 // The IIFE global the page's inline `onHomeyReady` reads `start` from.
 const GLOBAL_NAME = 'HeatzyWebview'
@@ -16,11 +16,18 @@ const GLOBAL_NAME = 'HeatzyWebview'
 // validated `outDir`), and the CLI packs exactly this directory.
 const OUT_ROOT = '.homeybuild'
 
+const HASH_LENGTH = 8
+
 const entryPoints = ['settings/index.mts']
 
 const pages = ['settings/index.html']
 
-const sharedOptions = {
+// A local asset reference: an attribute value (href/src) or a dynamic
+// import specifier, with an optional existing stamp.
+const REFERENCE =
+  /(?<prefix>href="|src="|import\('\.\/)(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>["'\)])/gv
+
+const sharedOptions: BuildOptions = {
   bundle: true,
   legalComments: 'none',
   logLevel: 'info',
@@ -30,7 +37,7 @@ const sharedOptions = {
 
 await Promise.all(
   entryPoints.flatMap((entryPoint) => {
-    const outBase = path.join(OUT_ROOT, entryPoint.replace(/\.mts$/u, ''))
+    const outBase = path.join(OUT_ROOT, entryPoint.replace(/\.mts$/v, ''))
     return [
       build({
         ...sharedOptions,
@@ -64,7 +71,10 @@ await Promise.all(
 await Promise.all(
   entryPoints.flatMap((entryPoint) =>
     ['.js', '.mjs'].map(async (extension) =>
-      rm(entryPoint.replace(/\.mts$/u, extension), { force: true }),
+      rm(
+        entryPoint.replace(/\.mts$/v, () => extension),
+        { force: true },
+      ),
     ),
   ),
 )
@@ -76,36 +86,66 @@ await Promise.all(
 // CLI flow (its pre-process copy runs before `npm run build`) and is
 // absent in a standalone suite run, which only proves the bundles
 // compile.
-const hashOf = async (filePath) => {
+const hashOf = async (filePath: string): Promise<string> => {
   const content = await readFile(filePath)
-  return createHash('sha256').update(content).digest('hex').slice(0, 8)
+  return createHash('sha256')
+    .update(content)
+    .digest('hex')
+    .slice(0, HASH_LENGTH)
 }
 
-const stampHtml = async (htmlPath) => {
-  let html = ''
+const collectHashes = async (
+  html: string,
+  directory: string,
+): Promise<ReadonlyMap<string, string>> => {
+  const files = new Set<string>()
+  for (const match of html.matchAll(REFERENCE)) {
+    const { file = '' } = match.groups ?? {}
+    if (file !== '') {
+      files.add(file)
+    }
+  }
+  return new Map(
+    await Promise.all(
+      [...files].map(async (file): Promise<[string, string]> => [
+        file,
+        await hashOf(path.join(directory, file)),
+      ]),
+    ),
+  )
+}
+
+// Stamp only within a reference context, so the same filename written
+// elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
+// rather than through a `replaceAll` callback, whose loosely typed rest
+// arguments cannot carry the named groups safely.
+const stampReferences = (
+  html: string,
+  hashes: ReadonlyMap<string, string>,
+): string => {
+  let stamped = ''
+  let cursor = 0
+  for (const match of html.matchAll(REFERENCE)) {
+    const { file = '', prefix = '', suffix = '' } = match.groups ?? {}
+    const hash = hashes.get(file) ?? ''
+    stamped += `${html.slice(cursor, match.index)}${prefix}${file}?v=${hash}${suffix}`
+    cursor = match.index + match[0].length
+  }
+  return stamped + html.slice(cursor)
+}
+
+const stampHtml = async (htmlPath: string): Promise<void> => {
+  let html: string
   try {
     html = await readFile(htmlPath, 'utf8')
   } catch {
+    // The page copy only exists in the CLI flow; a standalone suite run
+    // has nothing to stamp.
     return
   }
-  const directory = path.dirname(htmlPath)
-  // A local asset reference: an attribute value (href/src) or a dynamic
-  // import specifier, with an optional existing stamp.
-  const reference =
-    /(href="|src="|import\('\.\/)([^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?(["')])/gu
-  // Hash each referenced asset up front — the replace below is sync.
-  const hashes = new Map()
-  for (const [, , file] of html.matchAll(reference)) {
-    if (!hashes.has(file)) {
-      hashes.set(file, await hashOf(path.join(directory, file)))
-    }
-  }
-  // Stamp only within a reference context, so the same filename written
-  // elsewhere (e.g. a comment) is never rewritten.
-  const stamped = html.replaceAll(
-    reference,
-    (_match, prefix, file, suffix) =>
-      `${prefix}${file}?v=${hashes.get(file)}${suffix}`,
+  const stamped = stampReferences(
+    html,
+    await collectHashes(html, path.dirname(htmlPath)),
   )
   if (stamped !== html) {
     await writeFile(htmlPath, stamped)

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,6 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "exclude": ["*.config.ts", "tests", "settings"],
+  "exclude": ["*.config.ts", "scripts", "tests", "settings"],
   "extends": "./tsconfig.json"
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ const swcPlugin = swc.vite({
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      exclude: ['settings/**/*.mts'],
+      exclude: ['scripts/**/*.mts', 'settings/**/*.mts'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
## What

The build scripts become **TypeScript, run natively by Node** — no transpilation, no new tooling:

- `scripts/bundle.mjs` → `scripts/bundle.mts` (and `sync-capability-definitions` in com.melcloud)
- `build:assets` calls the `.mts` directly (`node scripts/bundle.mts`)
- the yaml eslint block gets `files: ["**/*.{yaml,yml}"]` — it used to apply to every file, was the only block reaching `.mjs`, and leaked 28 inert `yml/*` rules onto every `.mts`

## Why TypeScript, not a JS lint block

This PR first shipped a `js.recommended + unicorn` block for `.mjs`. Review asked whether that was the best practice — measured answer: **no**.

| option | measured outcome |
|---|---|
| js/unicorn block (v1 of this PR) | lints, but diverges from the repo's curated rule set (raw `unicorn` without the ledger overrides) and stays untyped |
| `tsConfigs.disableTypeChecked` on `.mjs` | **11 violations, some unsatisfiable in JS** — `explicit-function-return-type` demands annotations `.mjs` cannot write → dead end of disables |
| **`.mts` run natively (this PR)** | full doctrine applies: typed lint, typecheck, strict, zero special-casing |

The stack was already built for it: `engines >= 22.19` (Node runs TS natively since 22.18, type stripping on by default — verified on this machine), and the tsconfig sets **`erasableSyntaxOnly: true`**, the exact flag that guarantees stripping-safe TypeScript.

## What the typed pipeline caught

Converting surfaced real fixes the untyped block missed: `JSON.parse` results typed `unknown` and narrowed instead of flowing as `any`; regexes upgraded to the `v` flag (`require-unicode-regexp`); the `replaceAll` callback — whose rest args cannot carry named groups safely under typed lint — replaced by a cursor-wise rebuild; magic numbers named.

## Wiring, so nothing else moves

- `tsconfig.build.json` excludes `scripts` → **nothing emitted into `.homeybuild`** (verified: no `.homeybuild/scripts`)
- vitest excludes `scripts/**` from coverage, like the other process-level sources
- docs and test comments updated to the `.mts` names

## Functionally verified

Full build + simulated CLI page copy: **byte-identical `?v=` hashes** to the old script, stamps only inside reference contexts, second run idempotent. In com.melcloud, `sync-capability-definitions.mts` re-run produces **zero diff** under `vendor/` and the drift test passes.

Edited together with its two siblings, as the shared-file rule requires.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level