### PR TITLE
chore: pick up heatzy-api 11.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "23.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/heatzy-api": "11.0.0",
+        "@olivierzal/heatzy-api": "11.0.1",
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@olivierzal/heatzy-api": {
-      "version": "11.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/11.0.0/c3a039d2bf886e3176d2a62f625dfe38d32a5eff",
-      "integrity": "sha512-+japTkOnwdWUvq0BpK1KVa0u8/eOuRTYmSz0pqo3sLnmEKHF0IfQlublr+POpTjZmfkBBGHdVMs7T3x2OrswYg==",
+      "version": "11.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/11.0.1/d490d8b214ccf3df263606fa53ca017dc27f7297",
+      "integrity": "sha512-XU2y6/dUtWgfy/KbIwRBYsAhOkwuixGtFcb1otvbh3XcbyMefHizo/XoYHZp+4BFd7gOOhKTwWBk+C64FMeOSw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/heatzy-api": "11.0.0",
+    "@olivierzal/heatzy-api": "11.0.1",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

`@olivierzal/heatzy-api` `11.0.0` → `11.0.1` (exact pin, per the adoption policy set in #1058).

## Why no release with it

11.0.1 keeps a present-`undefined` write off the wire on V2+ devices (OlivierZal/heatzy-api#1163). This app's exposure was **theoretical**: `#buildUpdateData` spreads converter outputs built from real capability values, so an all-`undefined` payload does not occur in practice — and the app additionally guards on `Object.keys(updateData).length`. The bump keeps `main` current; the fix rides the next release.

Typecheck passes with zero source edits — the fix is behaviour-internal to the library.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level