### PR TITLE
chore: close the parity gaps the wave left

### DIFF
--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -62,7 +62,7 @@ jobs:
                cause and the needed fix.
     timeout-minutes: 30
 name: Claude Dependabot Fix
-on: # zizmor: ignore[dangerous-triggers]
+on:
   workflow_run:
     types: [completed]
     workflows: [CI, Validate]

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  # workflow_run is deliberate there: it is the only trigger that keeps
+  # CLAUDE_CODE_OAUTH_TOKEN out of dependabot's reach (see the header
+  # comment in the workflow), and the job gates on the dependabot actor.
+  dangerous-triggers:
+    ignore:
+      - claude-dependabot-fix.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,9 @@ coverage.
   stylesheet at runtime, which is not in the repo and not available
   offline.
 - App-API surface conventions (aligned on com.melcloud): paths are
-  kebab-case REST, `get*` for GET and `update*` for PUT (never `set*`),
+  kebab-case REST, `get*` for GET — except `is*` for a boolean GET —,
+  `update*` for PUT (never `set*`), and a business verb for POST
+  (`authenticate` on `/sessions`, `logWebviewBoot` on `/boot-error`),
   breadcrumbs log the verbed form (`'GET /settings/devices'`). Handler
   renames are wire-invisible (routing is method+path).
   `settings/callback-api.mts` is the settings page's transport (the
@@ -142,6 +144,26 @@ coverage.
   manifest capabilities and registers condition/action run listeners
   mechanically; the settable surface is the driver's `setCapabilities`
   list.
+
+## Naming & authored-content conventions
+
+- What `@typescript-eslint/naming-convention` cannot see is convention
+  too: booleans read as questions even untyped (`isX`/`hasX`), handlers
+  as verbs; a name states what the thing IS, never its history. Test
+  files are named after the unit under test (`<module>.test.ts`); shared
+  test helpers keep their family's names — apps say `assertDefined` and
+  `mock(overrides)` where the libraries say `defined` and
+  `mock(value?)`: two test families, deliberately not unified.
+- Static markup and styles live in `.html`/`.css` files. TS builds DOM
+  only when the content is programmatic (computed values, per-item
+  nodes), via `createElement` — never `innerHTML` (`no-unsafe-dom-html`
+  enforces it). Inline style writes are reserved for values CSS cannot
+  express; anything static belongs in the stylesheet, following the
+  CSS/HTML lint rules' spirit even where no rule captures it.
+- The webview runtime floor (es2023, no `Object.groupBy`, no iterator
+  helpers) is enforced by a scoped lint block over `settings/` — the
+  tsconfig cannot express two runtimes in one project. Node-side code
+  may use the newer APIs freely.
 
 ## Lint doctrine
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -908,6 +908,40 @@ const config: Config[] = defineConfig([
     ],
   },
   {
+    // The webview runtime floor (see CLAUDE.md): es2023 array methods are
+    // the ceiling — no `Object.groupBy`/`Map.groupBy`, no iterator
+    // helpers (`.entries().map()` and friends). The tsconfig `lib`
+    // cannot express this (one project, two runtimes), so the constraint
+    // lives here.
+    files: ['settings/**/*.mts'],
+    rules: {
+      'no-restricted-properties': [
+        'error',
+        {
+          message:
+            'es2024+: old iOS webview engines lack it (CLAUDE.md webview floor).',
+          object: 'Object',
+          property: 'groupBy',
+        },
+        {
+          message:
+            'es2024+: old iOS webview engines lack it (CLAUDE.md webview floor).',
+          object: 'Map',
+          property: 'groupBy',
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          message:
+            'Iterator helpers are 2025-era: old iOS webview engines lack them (CLAUDE.md webview floor). Spread into an array first.',
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.property.name=/^(drop|every|filter|find|flatMap|forEach|map|reduce|some|take|toArray)$/][callee.object.type='CallExpression'][callee.object.callee.type='MemberExpression'][callee.object.callee.property.name=/^(entries|keys|values)$/][callee.object.callee.object.name!='Object']",
+        },
+      ],
+    },
+  },
+  {
     files: ['lib/homey.mts'],
     rules: {
       'import-x/no-extraneous-dependencies': 'off',


### PR DESCRIPTION
Final sweep after the audit wave: three repo-wide promises had landed only in com.melcloud.

1. **The webview-floor lint guard** — this app has the same es2023-constrained settings webview; the guard is mutation-verified here too (`Object.groupBy` probe caught, restored).
2. **The naming & authored-content doctrine sections** (naming beyond the eslint rule, static-vs-programmatic markup, the floor's enforcement note).
3. **The completed route conventions** — `is*` boolean GETs and business-verb POSTs, practiced by the surfaces since their harmonization but documented only in com.melcloud.

Suite green: format/lint/typecheck/coverage 100%/homey:validate.