### PR TITLE
build(deps-dev): bump transitive postcss to 8.5.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6286,9 +6286,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
GHSA advisory (moderate, dev scope): postcss <= 8.5.22 reads arbitrary `.map` files through an attacker-controlled `sourceMappingURL` when `from` is unset — incomplete fix of GHSA-6g55-p6wh-862q, patched in 8.5.23. Lockfile-only refresh (`npm update postcss`); postcss is not a direct dependency. Full suite green.

The same bump lands across the family: com.melcloud is already on 8.5.25; melcloud-api and heatzy-api follow once their in-flight dependency PRs merge, to avoid lockfile conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
