### PR TITLE
docs: point the Node requirement at .nvmrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ English, French.
 
 ## Development
 
-Requirements: Node.js 22 and the [Homey CLI](https://apps.developer.homey.app/the-basics/getting-started) (`npx homey`).
+Requirements: Node.js 22 (see `.nvmrc`) and the [Homey CLI](https://apps.developer.homey.app/the-basics/getting-started) (`npx homey`).
 
 ```bash title="Common commands"
 npm ci               # install dependencies


### PR DESCRIPTION
Parity fix with the two sibling apps: the Development section now references `.nvmrc` (22.19) like com.melcloud and com.melcloud.extension do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
