### PR TITLE
docs: record the compile-floor probe verdict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,10 +174,14 @@ coverage.
   enforces it). Inline style writes are reserved for values CSS cannot
   express; anything static belongs in the stylesheet, following the
   CSS/HTML lint rules' spirit even where no rule captures it.
-- The webview runtime floor (es2023, no `Object.groupBy`, no iterator
-  helpers) is enforced by a scoped lint block over `settings/` — the
-  tsconfig cannot express two runtimes in one project. Node-side code
-  may use the newer APIs freely.
+- The webview runtime floor (es2023: no `Object.groupBy`, no iterator
+  helpers, no `v` regex flag) is enforced by a scoped lint block over
+  `settings/` — the tsconfig cannot express two runtimes in one
+  project. A `tsconfig.webview.json` floor was probed and refused on
+  com.melcloud (2026-08-06): tsc checks the import CLOSURE, which
+  crosses into node-side code — the same shape exists here
+  (`settings/` imports shared `lib/` and `types/` modules). Node-side
+  code may use the newer APIs freely.
 
 ## Lint doctrine
 


### PR DESCRIPTION
Follow-up to the "sub-tsconfig vs lint blocklist" question: the compile-time floor is the stronger form in principle, but the probe (native TS7, `tsconfig.webview.json` with target/lib ES2023) refused it empirically — `include` does not bound a TypeScript project; the compiler checks the whole import closure, and the webview-facing types reach node-side es2024/2025 code through the drivers' type barrel. Making it work means decoupling webview-facing types from driver classes (pure DTOs) — an architecture wave, not a toolchain toggle. The doctrine records the verdict and its revisit condition; the scoped lint block (now covering the `v` regex flag) remains the floor's enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
