### PR TITLE
fix: keep the persisted derogation end across a restart

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,3 @@
 /.homeycompose/app.json
 /app.json
 /locales/
-/README.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
+  "js/ts.tsdk.path": "node_modules/@typescript/native",
   "sonarlint.connectedMode.project": {
     "connectionId": "olivierzal",
     "projectKey": "OlivierZal_com.heatzy"
-  },
-  "typescript.native-preview.tsdk": "node_modules/@typescript/native"
+  }
 }

--- a/drivers/heatzy/device.mts
+++ b/drivers/heatzy/device.mts
@@ -1,5 +1,6 @@
 import {
   type DeviceFacadeAny,
+  type DeviceV2Facade,
   type PostAttributes,
   DerogationMode,
   getTargetTemperature,
@@ -10,6 +11,7 @@ import {
   supportsGlow,
   supportsPro,
   supportsV2,
+  Temporal,
 } from '@olivierzal/heatzy-api'
 
 import type {
@@ -303,6 +305,16 @@ export default class HeatzyDevice extends Device {
     await this.syncFromDevice()
   }
 
+  // Reads mirror #setValue's manifest-mismatch guard: an absent
+  // capability reads as `null` instead of throwing.
+  #getValue<TKey extends keyof Capabilities>(
+    capability: TKey,
+  ): Capabilities[TKey] | null {
+    return this.hasCapability(capability)
+      ? this.getCapabilityValue(capability)
+      : null
+  }
+
   async #init(device: DeviceFacadeAny): Promise<void> {
     await this.#setCapabilities(device.product)
     fireAndForget(
@@ -314,6 +326,25 @@ export default class HeatzyDevice extends Device {
     )
   }
 
+  // Keep the persisted label only while it can still be the running
+  // derogation's: same mode, same duration, end still ahead. A re-armed
+  // identical derogation during downtime slips through — the retained
+  // end is then early, never late — which beats wiping a valid label on
+  // every restart.
+  #keepsStoredDerogationEnd(device: DeviceV2Facade): boolean {
+    const { derogationMode, derogationTime } = device
+    const storedEnd = this.getStoreValue('derogationEnd')
+    return (
+      derogationMode !== DerogationMode.off &&
+      this.#getValue('derog_end') !== null &&
+      this.#getValue('heater_operation_mode') ===
+        derogationModeKeys[derogationMode] &&
+      this.#getValue('derog_time') === String(derogationTime) &&
+      storedEnd !== null &&
+      storedEnd > Temporal.Now.instant().epochMilliseconds
+    )
+  }
+
   #registerCapabilityListeners(): void {
     this.registerMultipleCapabilityListener(
       [...SETTABLE_CAPABILITIES],
@@ -322,6 +353,26 @@ export default class HeatzyDevice extends Device {
       },
       DEBOUNCE_DELAY,
     )
+  }
+
+  // The wire carries no derogation start, so the facade cannot compute
+  // an end it never saw begin: after an app restart mid-derogation it
+  // reports `null` for the rest of that derogation. The label Homey
+  // persisted across the restart IS the missing memory — keep it while
+  // the derogation still matches the one it was rendered for.
+  async #resolveDerogationEnd(device: DeviceV2Facade): Promise<string | null> {
+    const { derogationEndDate, derogationEndString } = device
+    if (derogationEndString !== null) {
+      await this.#storeDerogationEnd(
+        derogationEndDate?.epochMilliseconds ?? null,
+      )
+      return derogationEndString
+    }
+    if (this.#keepsStoredDerogationEnd(device)) {
+      return this.#getValue('derog_end')
+    }
+    await this.#storeDerogationEnd(null)
+    return null
   }
 
   // Delay sync to let Homey's optimistic UI update and debounce settle.
@@ -427,15 +478,12 @@ export default class HeatzyDevice extends Device {
       return
     }
 
-    const {
-      derogationEndString,
-      derogationMode,
-      derogationTime,
-      isLocked,
-      isTimer,
-    } = device
+    const { derogationMode, derogationTime, isLocked, isTimer } = device
+    // Resolved before the parallel writes below overwrite the stored
+    // derogation parameters the keep-guard compares against.
+    const derogationEnd = await this.#resolveDerogationEnd(device)
     await Promise.all([
-      this.#setValue('derog_end', derogationEndString),
+      this.#setValue('derog_end', derogationEnd),
       this.#setValue(
         'heater_operation_mode',
         derogationModeKeys[derogationMode],
@@ -455,6 +503,12 @@ export default class HeatzyDevice extends Device {
   ): Promise<void> {
     if (this.hasCapability(capability)) {
       await this.setCapabilityValue(capability, value)
+    }
+  }
+
+  async #storeDerogationEnd(value: number | null): Promise<void> {
+    if (this.getStoreValue('derogationEnd') !== value) {
+      await this.setStoreValue('derogationEnd', value)
     }
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.projectKey=OlivierZal_com.heatzy
 sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.exclusions=**/*.jpg,**/*.png,coverage/**
+sonar.exclusions=**/*.png,coverage/**
 sonar.coverage.exclusions=tests/**,**/*.config.*,settings/**,scripts/**
 sonar.cpd.exclusions=**/*.config.*,settings/index.html

--- a/tests/unit/heatzy-device.test.ts
+++ b/tests/unit/heatzy-device.test.ts
@@ -24,6 +24,8 @@ import HeatzyDevice from '../../drivers/heatzy/device.mts'
 
 const DEBOUNCE_DELAY = 1000
 
+const DEROGATION_END_EPOCH = 1_800_000_000_000
+
 const ALL_CAPABILITIES: readonly string[] = [
   'alarm_presence',
   'derog_end',
@@ -127,6 +129,7 @@ const createFacade = (
   currentHumidity: 55,
   currentMode: Mode.comfort,
   currentTemperature: 20,
+  derogationEndDate: { epochMilliseconds: DEROGATION_END_EPOCH },
   derogationEndString: 'END',
   derogationMode: DerogationMode.boost,
   derogationTime: 60,
@@ -156,6 +159,18 @@ const createDevice = (driver: HeatzyDriver = createDriver()): HeatzyDevice => {
   const device = new HeatzyDevice()
   Object.defineProperty(device, 'driver', { configurable: true, value: driver })
   return device
+}
+
+// Mirrors createDevice's driver injection: the declared generic reader
+// cannot take a loose mock implementation through vi.mocked.
+const stubStoredCapabilities = (
+  device: HeatzyDevice,
+  values: Record<string, unknown>,
+): void => {
+  Object.defineProperty(device, 'getCapabilityValue', {
+    configurable: true,
+    value: (capability: string): unknown => values[capability] ?? null,
+  })
 }
 
 const getCallback = (): ((
@@ -738,6 +753,133 @@ describe(HeatzyDevice, () => {
         expect.anything(),
       )
       expect(device.setStoreValue).toHaveBeenCalledWith('previousMode', null)
+    })
+
+    it('should store the end instant alongside a fresh label', async () => {
+      const device = createDevice()
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setCapabilityValue).toHaveBeenCalledWith('derog_end', 'END')
+      expect(device.setStoreValue).toHaveBeenCalledWith(
+        'derogationEnd',
+        DEROGATION_END_EPOCH,
+      )
+    })
+
+    it('should keep the stored label across a restart mid-derogation', async () => {
+      configureFacade({ derogationEndDate: null, derogationEndString: null })
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'derogationEnd' ? Date.now() + 60_000 : undefined,
+      )
+      const device = createDevice()
+      stubStoredCapabilities(device, {
+        derog_end: 'STORED',
+        derog_time: '60',
+        heater_operation_mode: 'boost',
+      })
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setCapabilityValue).toHaveBeenCalledWith(
+        'derog_end',
+        'STORED',
+      )
+    })
+
+    it('should wipe the stored label when the derogation changed offline', async () => {
+      configureFacade({ derogationEndDate: null, derogationEndString: null })
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'derogationEnd' ? Date.now() + 60_000 : undefined,
+      )
+      const device = createDevice()
+      stubStoredCapabilities(device, {
+        derog_end: 'STORED',
+        derog_time: '30',
+        heater_operation_mode: 'boost',
+      })
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setCapabilityValue).toHaveBeenCalledWith('derog_end', null)
+      expect(device.setStoreValue).toHaveBeenCalledWith('derogationEnd', null)
+    })
+
+    it('should wipe the stored label once its end has passed', async () => {
+      configureFacade({ derogationEndDate: null, derogationEndString: null })
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'derogationEnd' ? Date.now() - 60_000 : undefined,
+      )
+      const device = createDevice()
+      stubStoredCapabilities(device, {
+        derog_end: 'STORED',
+        derog_time: '60',
+        heater_operation_mode: 'boost',
+      })
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setCapabilityValue).toHaveBeenCalledWith('derog_end', null)
+    })
+
+    it('should clear the label and the store when the derogation is off', async () => {
+      configureFacade({
+        derogationEndDate: null,
+        derogationEndString: null,
+        derogationMode: DerogationMode.off,
+      })
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'derogationEnd' ? Date.now() + 60_000 : undefined,
+      )
+      const device = createDevice()
+      stubStoredCapabilities(device, {
+        derog_end: 'STORED',
+        derog_time: '60',
+        heater_operation_mode: 'off',
+      })
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setCapabilityValue).toHaveBeenCalledWith('derog_end', null)
+      expect(device.setStoreValue).toHaveBeenCalledWith('derogationEnd', null)
+    })
+
+    it('should store a null instant when the label has no date', async () => {
+      configureFacade({ derogationEndDate: null })
+      const device = createDevice()
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setStoreValue).toHaveBeenCalledWith('derogationEnd', null)
+    })
+
+    it('should not rewrite an unchanged stored end instant', async () => {
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'derogationEnd' ? DEROGATION_END_EPOCH : undefined,
+      )
+      const device = createDevice()
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setStoreValue).not.toHaveBeenCalledWith(
+        'derogationEnd',
+        expect.anything(),
+      )
+    })
+
+    it('should read an absent derog_end capability as no stored label', async () => {
+      configureFacade({ derogationEndDate: null, derogationEndString: null })
+      getStoreValueMock.mockImplementation((key: string) =>
+        key === 'derogationEnd' ? Date.now() + 60_000 : undefined,
+      )
+      const device = createDevice()
+      vi.spyOn(device, 'hasCapability').mockImplementation(
+        (capability) => capability !== 'derog_end',
+      )
+      await device.syncFromDevice()
+      await settleDetached()
+
+      expect(device.setStoreValue).toHaveBeenCalledWith('derogationEnd', null)
     })
 
     it('should return early when the device is unavailable', async () => {

--- a/types/device-settings.mts
+++ b/types/device-settings.mts
@@ -12,5 +12,6 @@ export interface Settings extends Partial<Record<string, unknown>> {
 }
 
 export interface Store {
+  readonly derogationEnd: number | null
   readonly previousMode: PreviousMode | null
 }


### PR DESCRIPTION
Olivier's arbitration of the round-2 `derogation-at-first-sight` finding: the wire limitation stays in heatzy-api (no start timestamp → no derivable end), and the app becomes the database-backed client that bridges it.

**The guard** — `derog_end` was clobbered with `null` on every post-restart sync (the facade cannot compute an end it never saw begin). The device now resolves the label before the parallel tier writes: a fresh label is written and its raw instant stored (`derogationEnd` store value, write-on-change only); a `null` label with an ACTIVE derogation keeps the persisted capability value only while it can still belong to the running derogation — same stored `heater_operation_mode`, same stored `derog_time` (compared before this sync overwrites them), stored instant still ahead — and is cleared otherwise (mode off, parameters changed offline, end elapsed, capability absent).

**Accepted residual window** — a derogation re-armed with identical parameters while Homey was down keeps the earlier label: the retained end is then early, never late, which beats wiping a valid label on every restart.

**Tests** — eight new cases (keep, changed-offline, elapsed, off, fresh-label store, null-date store, unchanged-store skip, absent-capability read); mutation-checked: four fail without the guard, the keep scenario among them. Coverage stays 100 % on all four axes.

**Chores** — `/README.md` out of `.prettierignore` (zero prettier diff; formatting markdown is the norm), `typescript.native-preview.tsdk` → `js/ts.tsdk.path` in `.vscode/settings.json` (extension rename), `**/*.jpg` out of the Sonar exclusions (no jpg in this repo — store images are png).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3