### PR TITLE
fix: let the freeze dim outweigh the injected cascade

### DIFF
--- a/settings/index.css
+++ b/settings/index.css
@@ -58,7 +58,11 @@ details[open] > summary.homey-form-legend::before {
    `:disabled`) so nested fieldsets inside a frozen section do not
    compound the opacity; `pointer-events` because `disabled` only
    reaches form controls, not arbitrary interactive descendants. */
-fieldset[disabled] {
+/* The `body` ancestor outweighs the injected sheet's `all: unset` on
+   its reset fieldsets whatever the order: without it the section dim
+   can lose the cascade on-device, and the button neutralizer below then
+   leaves in-flight buttons fully opaque. */
+body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
Sibling hardening of com.melcloud's observed regression (OlivierZal/com.melcloud#1529): the `fieldset[disabled]` dim tied (0,1,1) with the injected sheet's fieldset resets, so injection order decided whether a frozen section dimmed — and the button neutralizer counts on that container dim. The `body` ancestor lifts the rule to (0,1,2), order-proof. Latent here (not reported), same mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3