### PR TITLE
feat: poke open webviews with the freshness handshake at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,10 @@ coverage.
   document from the HTTP cache; sessionStorage guard,
   `webview-freshness.mts`), whose fresh stamps pull the fresh assets;
   a mismatch that survives its refetch is reported to
-  `POST /boot-error`. Every failure
+  `POST /boot-error`. The app also emits a `webview_hashes_changed`
+  realtime event at its own boot; an open page re-runs the same
+  handshake on it — a second trigger of the one primitive, covering a
+  page left open across an app restart or update. Every failure
   path stays open: an unstamped page, an absent route or denied
   storage must never take a working webview down. Heatzy
   divergence from com.melcloud: the cached-HTML era here loaded
@@ -267,8 +270,10 @@ coverage.
   before acting either way (Copilot has been wrong about library
   semantics). Resolve the thread once settled; none left dangling.
 - SonarCloud must be spotless for a PR to merge: quality gate green,
-  zero open issues on its analysis, and 100 % coverage (within the
-  exclusions `sonar-project.properties` declares). A Sonar finding is
+  zero open issues on its analysis, 100 % coverage (within the
+  exclusions `sonar-project.properties` declares), and 0 % duplicated
+  lines across the WHOLE codebase — new and old alike, not just the
+  gate's new-code window. A Sonar finding is
   handled like a lint error — the code adapts, or the divergence is
   settled as a documented verdict (e.g. the `Number.NaN` convention in
   `eslint.config.ts`) — never merged over.

--- a/app.mts
+++ b/app.mts
@@ -153,6 +153,9 @@ export default class HeatzyApp extends App {
     })
     this.#facadeManager = new FacadeManager(this.#api)
     this.#createNotification(language)
+    // Poke any open webview to re-run its freshness handshake: an app
+    // (re)boot is exactly when the served hashes may have moved.
+    this.homey.api.realtime('webview_hashes_changed', null)
     fireAndForget(
       this.#logBootReady(),
       (...args: unknown[]) => {

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -572,8 +572,9 @@ const checkFreshness = async (homey: HomeySettings): Promise<boolean> =>
 
 // Boot pull, then push subscription: a stale page refetches itself
 // (the caller skips its init — the document is about to be replaced);
-// a fresh one subscribes to the app's boot poke and re-runs the same
-// handshake when it fires.
+// any page that stays — fresh, or stale but unable to refetch —
+// subscribes to the app's boot poke and re-runs the same handshake
+// when it fires.
 const startFreshness = async (homey: HomeySettings): Promise<boolean> => {
   if (await checkFreshness(homey)) {
     return true

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -559,19 +559,33 @@ const buildSections = async (context: PageContext): Promise<void> => {
   context.gate.markSaved()
 }
 
+// One freshness pass, shared by the boot pull and the app's realtime
+// poke; its breadcrumbs ride the declared boot-error route.
+const checkFreshness = async (homey: HomeySettings): Promise<boolean> =>
+  ensureFreshWebview(
+    'settings',
+    async () => homeyApiGet(homey, '/webview-hashes'),
+    (message) => {
+      reportFreshness(homey, message)
+    },
+  )
+
+// Boot pull, then push subscription: a stale page refetches itself
+// (the caller skips its init — the document is about to be replaced);
+// a fresh one subscribes to the app's boot poke and re-runs the same
+// handshake when it fires.
+const startFreshness = async (homey: HomeySettings): Promise<boolean> => {
+  if (await checkFreshness(homey)) {
+    return true
+  }
+  homey.on('webview_hashes_changed', () => {
+    fireAndForget(homey, checkFreshness(homey))
+  })
+  return false
+}
+
 const init = async (homey: HomeySettings): Promise<void> => {
-  // A stale cached page refetches itself once (never-cached address)
-  // instead of booting: skip
-  // the init — the document is about to be replaced.
-  if (
-    await ensureFreshWebview(
-      'settings',
-      async () => homeyApiGet(homey, '/webview-hashes'),
-      (message) => {
-        reportFreshness(homey, message)
-      },
-    )
-  ) {
+  if (await startFreshness(homey)) {
     return
   }
   const elements = getPageElements()

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -120,6 +120,8 @@ const mockApiInstance = {
 }
 
 const mockCreateNotification = vi.fn<() => Promise<void>>()
+
+const mockRealtime = vi.fn<(event: string, data: unknown) => void>()
 const mockGetDrivers = vi.fn<() => Record<string, unknown>>()
 const mockGetLanguage = vi.fn<() => string>()
 const mockGetTimezone = vi.fn<() => string>()
@@ -147,6 +149,7 @@ const createApp = (): InstanceType<typeof HeatzyApp> => {
       configurable: true,
       value: {
         __: mockTranslate,
+        api: { realtime: mockRealtime },
         clock: { getTimezone: mockGetTimezone },
         drivers: { getDrivers: mockGetDrivers },
         i18n: { getLanguage: mockGetLanguage },
@@ -248,6 +251,12 @@ describe(HeatzyApp, () => {
       await app.onInit()
 
       expect(mockSettingsUnset).toHaveBeenCalledWith('expireAt')
+    })
+
+    it('should poke open webviews with the freshness event at boot', async () => {
+      await app.onInit()
+
+      expect(mockRealtime).toHaveBeenCalledWith('webview_hashes_changed', null)
     })
 
     it('should construct the facade manager with the API client', async () => {


### PR DESCRIPTION
Second trigger of the freshness primitive, approved design — same wave as OlivierZal/com.melcloud.extension#1259: the app emits `webview_hashes_changed` (realtime, no payload) once at init, and an open settings page re-runs the exact same `ensureFreshWebview` call it used at boot (shared `checkFreshness`/`startFreshness`, Sonar whole-code duplication stays 0 %). Covers a page left open across an app restart or update; a page opened later boots through the already-merged pull trigger; a page cached before the handshake existed remains reachable by neither. Subscription form: `homey.on('webview_hashes_changed', …)` (settings SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3