### PR TITLE
docs: fold the stacked freeze-dim comments into one intent

### DIFF
--- a/settings/index.css
+++ b/settings/index.css
@@ -57,11 +57,10 @@ details[open] > summary.homey-form-legend::before {
    request is in flight — grey it like the buttons. Attribute (not
    `:disabled`) so nested fieldsets inside a frozen section do not
    compound the opacity; `pointer-events` because `disabled` only
-   reaches form controls, not arbitrary interactive descendants. */
-/* The `body` ancestor outweighs the injected sheet's `all: unset` on
-   its reset fieldsets whatever the order: without it the section dim
-   can lose the cascade on-device, and the button neutralizer below then
-   leaves in-flight buttons fully opaque. */
+   reaches form controls, not arbitrary interactive descendants. The
+   `body` ancestor outweighs the injected sheet's `all: unset` on its
+   reset fieldsets whatever the stylesheet order — the button
+   neutralizer below counts on this dim rendering. */
 body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -560,7 +560,7 @@ const buildSections = async (context: PageContext): Promise<void> => {
 }
 
 // One freshness pass, shared by the boot pull and the app's realtime
-// poke; its breadcrumbs ride the declared boot-error route.
+// poke.
 const checkFreshness = async (homey: HomeySettings): Promise<boolean> =>
   ensureFreshWebview(
     'settings',


### PR DESCRIPTION
Session cleanup review (pre-release), verified target by target. Only two residues survived scrutiny, both comment-level: the freeze-dim rule carried TWO stacked comment blocks (the original intent plus the cascade fix's prepended rationale) — now one block stating intent and constraint together, episode narration dropped; and `checkFreshness`'s doc repeated the breadcrumb-route clause its callee `reportFreshness` already owns.

Verified clean, no change needed: the derog_end guard (eight tests, eight distinct branches, store cleaned on every path, the defensive `?? null` is type-imposed), CLAUDE.md's freshness and Sonar paragraphs (leg naming checked against ci.yml), sonar/vitest/eslint configs post-churn (every remaining pattern has live occurrences; no orphan of the collapsed device project or of the dropped try-all flow mechanic), the manifest-derived flow registration, the locale recomposition (the notification keys it restored have live consumers), and the twin roster — byte-identical against com.melcloud across all seven files, the freshness test's single import-line variance being the documented by-design difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3