### PR TITLE
docs: state the Sonar bar above the free-tier gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,14 +269,18 @@ coverage.
   reasoned reply when it does not — verify claims against sources
   before acting either way (Copilot has been wrong about library
   semantics). Resolve the thread once settled; none left dangling.
-- SonarCloud must be spotless for a PR to merge: quality gate green,
-  zero open issues on its analysis, 100 % coverage (within the
-  exclusions `sonar-project.properties` declares), and 0 % duplicated
-  lines across the WHOLE codebase — new and old alike, not just the
-  gate's new-code window. A Sonar finding is
-  handled like a lint error — the code adapts, or the divergence is
-  settled as a documented verdict (e.g. the `Number.NaN` convention in
-  `eslint.config.ts`) — never merged over.
+- SonarCloud must be spotless for a PR to merge — and the quality gate
+  passing is necessary, NOT sufficient: the free-tier gate tolerates
+  3 % duplication on new code, lets code smells through, and cannot be
+  customized, so the real bar is ours, held in review. That bar is
+  zero on BOTH windows — new code and overall alike: zero open issues
+  of every kind (bugs, code smells, vulnerabilities) across the whole
+  project, 0 % duplicated lines across the whole codebase, and 100 %
+  coverage (within the exclusions `sonar-project.properties`
+  declares). A Sonar finding is handled like a lint error — the code
+  adapts, or the divergence is settled as a documented verdict (e.g.
+  the `Number.NaN` convention in `eslint.config.ts`) — never merged
+  over.
 - The SonarCloud project runs **CI-based analysis** (the `ci.yml` scan
   step on the Node 22 leg): **Automatic Analysis must stay DISABLED** in
   the project's Administration settings, or the CI scanner aborts with


### PR DESCRIPTION
Sibling of OlivierZal/com.melcloud#1534 — Olivier's standard in full: gate passing is necessary, not sufficient; zero issues and 0 % duplication on both windows, held in review since the free-tier gate cannot be customized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3