### PR TITLE
fix: freeze the credentials section while signing in or out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,10 @@ coverage.
   `tests/unit/api-route-guards.test.ts` pins the call sites (every
   webview path literal must match a declared route).
 - Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
-  settings Apply/Refresh pair — never re-derive its invariant at a call
-  site. The gate also freezes the gated
+  settings Apply/Refresh pair AND the credentials sign-in/reset pair
+  (sign-in arms through `isActionable` only when both credential fields
+  are filled; reset is its busy-gated Refresh) — never re-derive its
+  invariant at a call site. The gate also freezes the gated
   fieldsets while a request is in flight (container `disabled` +
   `aria-busy`, so a control's own domain `disabled` survives the thaw):
   every success path rewrites the fields, so a mid-flight edit would be

--- a/settings/index.css
+++ b/settings/index.css
@@ -53,6 +53,21 @@ details[open] > summary.homey-form-legend::before {
   opacity: 0.5;
 }
 
+/* Plain containers promoted to fieldsets so one `disabled` flip
+   freezes a whole gated form region: none of the UA fieldset chrome
+   (border, padding, min-inline-size) may surface, and the `body`
+   ancestor outweighs the injected sheet's fieldset styling whatever
+   the stylesheet order. Explicit `display: block` because WebKit
+   renders inline fieldsets atomically; no busy-scope fieldset here is
+   ever `hidden`, so the display carries no hidden-vs-block tie. */
+body fieldset.busy-scope {
+  border: 0;
+  display: block;
+  margin: 0;
+  min-inline-size: 0;
+  padding: 0;
+}
+
 /* A dirty-gate freeze sets `disabled` on the gated fieldset while its
    request is in flight — grey it like the buttons. Attribute (not
    `:disabled`) so nested fieldsets inside a frozen section do not

--- a/settings/index.html
+++ b/settings/index.html
@@ -56,7 +56,7 @@
             settled), expanded while signed out. -->
         <details id="authentication" class="homey-form-fieldset">
             <summary class="homey-form-legend" data-i18n="settings.authenticate.legend">Credentials</summary>
-            <div id="login"></div>
+            <fieldset id="login" class="busy-scope"></fieldset>
             <div class="homey-form-group container">
                 <button
                     id="reset_credentials"

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -478,6 +478,10 @@ const pushLogOut = async (context: PageContext): Promise<void> => {
   if (state.passwordElement !== null) {
     state.passwordElement.value = ''
   }
+  // Re-baseline on the cleared form: the gate's saved snapshot would
+  // otherwise keep referencing the old serialized password until the
+  // page closes.
+  context.credentialsGate.markSaved()
   setAuthenticatedState(elements, false)
 }
 

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -27,6 +27,7 @@ const commonElementTypes = new Set(['checkbox', 'dropdown'])
 type HTMLValueElement = HTMLInputElement | HTMLSelectElement
 
 interface PageContext {
+  readonly credentialsGate: DirtyGate
   readonly elements: PageElements
   readonly gate: DirtyGate
   readonly homey: HomeySettings
@@ -38,7 +39,7 @@ interface PageElements {
   readonly authenticate: HTMLButtonElement
   readonly authentication: HTMLDetailsElement
   readonly devices: HTMLFieldSetElement
-  readonly login: HTMLDivElement
+  readonly login: HTMLFieldSetElement
   readonly refreshSettings: HTMLButtonElement
   readonly resetCredentials: HTMLButtonElement
   readonly settingsCommon: HTMLDivElement
@@ -88,7 +89,7 @@ const getPageElements = (): PageElements => ({
   authenticate: getElement('authenticate', HTMLButtonElement),
   authentication: getElement('authentication', HTMLDetailsElement),
   devices: getElement('devices', HTMLFieldSetElement),
-  login: getElement('login', HTMLDivElement),
+  login: getElement('login', HTMLFieldSetElement),
   refreshSettings: getElement('refresh_settings_common', HTMLButtonElement),
   resetCredentials: getElement('reset_credentials', HTMLButtonElement),
   settingsCommon: getElement('settings_common', HTMLDivElement),
@@ -148,29 +149,6 @@ const translatePage = (homey: HomeySettings): void => {
       if (translation !== '' && translation !== key) {
         element.textContent = translation
       }
-    }
-  }
-}
-
-const disableButton = (element: HTMLButtonElement, isDisabled = true): void => {
-  // Native `disabled` (not a pointer-events class): it blocks keyboard
-  // re-fire (no double POST), greys the control, and is announced to
-  // screen readers.
-  element.disabled = isDisabled
-}
-
-const withDisabledButtons = async (
-  elements: readonly HTMLButtonElement[],
-  action: () => Promise<void>,
-): Promise<void> => {
-  for (const element of elements) {
-    disableButton(element)
-  }
-  try {
-    await action()
-  } finally {
-    for (const element of elements) {
-      disableButton(element, false)
     }
   }
 }
@@ -452,8 +430,31 @@ const pushCredentials = async (
   setAuthenticatedState(elements, true)
 }
 
+// An empty credential can only produce the failure alert, so sign-in
+// arms only when the form could actually sign in; the caller hands
+// over initialized consts, so the construction-time recompute may run
+// the predicate safely (fields not built yet read as empty — the
+// sign-in button starts greyed).
+const createCredentialsGate = (
+  elements: PageElements,
+  state: PageState,
+): DirtyGate =>
+  createDirtyGate({
+    applyElement: elements.authenticate,
+    fieldsetElements: [elements.login],
+    refreshElements: [elements.resetCredentials],
+    isActionable: (): boolean =>
+      (state.usernameElement?.value ?? '').trim() !== '' &&
+      (state.passwordElement?.value ?? '') !== '',
+    serialize: (): string =>
+      JSON.stringify([
+        state.usernameElement?.value ?? '',
+        state.passwordElement?.value ?? '',
+      ]),
+  })
+
 const authenticate = async (context: PageContext): Promise<void> => {
-  const { elements, homey, state } = context
+  const { homey, state } = context
   // Trimmed: mobile autocomplete appends a space after the email.
   const username = (state.usernameElement?.value ?? '').trim()
   const password = state.passwordElement?.value ?? ''
@@ -461,13 +462,8 @@ const authenticate = async (context: PageContext): Promise<void> => {
     await alertMessage(homey, homey.__('settings.authenticate.failure'))
     return
   }
-  await withDisabledButtons(
-    [elements.authenticate, elements.resetCredentials],
-    async () =>
-      pushCredentials(context, {
-        password,
-        username,
-      } satisfies LoginCredentials),
+  await context.credentialsGate.runBusy(async () =>
+    pushCredentials(context, { password, username } satisfies LoginCredentials),
   )
 }
 
@@ -486,16 +482,13 @@ const pushLogOut = async (context: PageContext): Promise<void> => {
 }
 
 const logOut = async (context: PageContext): Promise<void> => {
-  const { elements, homey } = context
+  const { homey } = context
   if (
     !(await homeyConfirm(homey, homey.__('settings.authenticate.resetConfirm')))
   ) {
     return
   }
-  await withDisabledButtons(
-    [elements.authenticate, elements.resetCredentials],
-    async () => pushLogOut(context),
-  )
+  await context.credentialsGate.runBusy(async () => pushLogOut(context))
 }
 
 const refreshFromDeviceUpdate = async (context: PageContext): Promise<void> => {
@@ -553,10 +546,17 @@ const buildSections = async (context: PageContext): Promise<void> => {
     key: 'password',
     value: credentials.password,
   })
+  context.credentialsGate.wire(
+    [state.usernameElement, state.passwordElement].filter(
+      (element) => element !== null,
+    ),
+  )
   await fetchDeviceSettings(context)
   generateCommonSettings(context, driverSettings)
-  // Snapshot the pristine state once the sections are built.
+  // Snapshot the pristine state once the sections are built; the
+  // credentials rebaseline also re-arms sign-in for prefilled fields.
   context.gate.markSaved()
+  context.credentialsGate.markSaved()
 }
 
 // One freshness pass, shared by the boot pull and the app's realtime
@@ -597,6 +597,7 @@ const init = async (homey: HomeySettings): Promise<void> => {
     usernameElement: null,
   }
   const context: PageContext = {
+    credentialsGate: createCredentialsGate(elements, state),
     elements,
     // `elements` and `state` are initialized consts here, so the
     // construction-time recompute may run the predicate safely (an


### PR DESCRIPTION
Olivier's on-device observation, confirmed in code: during authentication only the two buttons were disabled (`withDisabledButtons`) — the username/password fields stayed editable through the round-trip. The section now runs through the ONE gating primitive instead of ad-hoc helpers:

- the `#login` container is promoted to a `busy-scope` fieldset (chrome reset added to the CSS in the body-prefixed, order-proof family form; no busy-scope fieldset here is ever hidden);
- `createCredentialsGate`: sign-in is the gate's Apply — armed through `isActionable` only when both fields are filled (trimmed username), so the empty-credentials alert becomes a belt; reset is its busy-gated Refresh; both actions run through `runBusy`, freezing the fields for the whole round-trip;
- the credential inputs are wired into the gate at build time and rebaselined after prefill, so stored credentials arm sign-in immediately;
- `disableButton`/`withDisabledButtons` (the ad-hoc re-derivation of the gate's invariant) are deleted;
- CLAUDE.md's dirty-gate paragraph now names the credentials pair among the call sites.

**Worth an on-device check** per the injected-sheet doctrine: open settings signed out — sign-in greyed until both fields are filled; during sign-in (and reset) the fields dim and freeze with both buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3