### PR TITLE
build(deps): adopt heatzy-api 12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "23.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/heatzy-api": "11.0.1",
+        "@olivierzal/heatzy-api": "12.0.0",
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
@@ -1122,12 +1122,12 @@
       }
     },
     "node_modules/@olivierzal/heatzy-api": {
-      "version": "11.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/11.0.1/d490d8b214ccf3df263606fa53ca017dc27f7297",
-      "integrity": "sha512-XU2y6/dUtWgfy/KbIwRBYsAhOkwuixGtFcb1otvbh3XcbyMefHizo/XoYHZp+4BFd7gOOhKTwWBk+C64FMeOSw==",
+      "version": "12.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/12.0.0/8c026fd785e921aadaf94d918a15ada647564fcd",
+      "integrity": "sha512-2CBfpsdcFYmERSKc+99dlxrMjcQ1S8afvLaoAEnncWBlhQaUTMlHG6Ws7+GCKr4EC0kpyFgRuyDTAC35qblHiw==",
       "license": "MIT",
       "dependencies": {
-        "temporal-polyfill": "^1.0.1",
+        "temporal-polyfill": "^1.0.3",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -6668,19 +6668,19 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
-      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.3.tgz",
+      "integrity": "sha512-U8vuzZBc+dfMIfl8wXWcedfI7AJCxJjjVBIRpJUvIz5+UAp555UJDHguKsfZqHWaHRSdVUThm7mqqIWhN/xPBQ==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "1.0.0",
+        "temporal-spec": "1.0.1",
         "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
-      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
       "license": "Apache-2.0"
     },
     "node_modules/temporal-utils": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/heatzy-api": "11.0.1",
+    "@olivierzal/heatzy-api": "12.0.0",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {


### PR DESCRIPTION
Exact-pin adoption of the 12.0.0 major. The breaking surface lands clean here: `updateValues` results were already discarded, and the dropped symbols (`toAuthFailure`, `Data`, `ErrorData`, `Resolved`) had no consumer in this repo (verified during round 2). The Glow write clamp and the nested-object redaction fix arrive with it. Full suite green: typecheck, lint, 100 % coverage, publish-level validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3