### PR TITLE
build(deps): adopt heatzy-api 12.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "23.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/heatzy-api": "12.0.0",
+        "@olivierzal/heatzy-api": "12.0.1",
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@olivierzal/heatzy-api": {
-      "version": "12.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/12.0.0/8c026fd785e921aadaf94d918a15ada647564fcd",
-      "integrity": "sha512-2CBfpsdcFYmERSKc+99dlxrMjcQ1S8afvLaoAEnncWBlhQaUTMlHG6Ws7+GCKr4EC0kpyFgRuyDTAC35qblHiw==",
+      "version": "12.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/12.0.1/157e46babbac311747141f0a760a1b85971d52a0",
+      "integrity": "sha512-u/Il0epm+1av5FB/YvZigRxnyqHAgwuCmbytzPMvEKXV+/FqlxN1A/jexRB2sDmz73L1AALP6ZFGEE6em4ppfw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@olivierzal/heatzy-api": "12.0.0",
+    "@olivierzal/heatzy-api": "12.0.1",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {


### PR DESCRIPTION
Exact-pin adoption of the credentials-persistence patch: a failed sign-in (settings page, pairing and repair alike — the one `authenticate` choke point) leaves the stored pair and session untouched. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3