### PR TITLE
chore(release): 23.2.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -58,5 +58,9 @@
   "23.1.0": {
     "en": "Signing in no longer reports success when your devices could not be loaded: instead of an empty device list, the app now tells you what went wrong.",
     "fr": "La connexion ne s'annonce plus réussie lorsque vos appareils n'ont pas pu être chargés : au lieu d'une liste vide, l'app vous indique désormais ce qui a échoué."
+  },
+  "23.2.0": {
+    "en": "The settings page now locks its forms while a change is being applied, refreshes itself after an app update, and shows a setting as undecided when your devices disagree instead of picking one of them. Your credentials are saved only once signing in succeeds, and a running derogation keeps its end time across a restart.",
+    "fr": "La page de réglages fige désormais ses formulaires pendant l'application d'un changement, se met à jour d'elle-même après une mise à jour de l'app, et affiche un réglage comme indéterminé lorsque vos appareils divergent au lieu d'en choisir un. Vos identifiants ne sont enregistrés qu'une fois la connexion réussie, et une dérogation en cours conserve son heure de fin après un redémarrage."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -95,5 +95,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.1.0"
+  "version": "23.2.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,12 @@ coverage.
   SECURITY.md, CLAUDE.md) — never a later sweep; the 2026-08 README
   audit caught exactly the drift this prevents (a shipped Home ATW
   driver absent from its README, a stale `Result` kind list).
+- A settling pass closes every substantive wave: before its work is
+  released, re-read the wave's own diff for what the churn left behind
+  — history-narrating comments, orphaned helpers or config entries,
+  factorizations the fix made obvious — and fold the findings into a
+  targeted follow-up. Features land first, the pass runs after, so it
+  covers them; it is scoped to the wave's diff, never a full re-review.
 
 - `@olivierzal/heatzy-api` is pinned EXACTLY, never with a caret: the
   library's breaking changes are self-published, adoption is an explicit

--- a/app.json
+++ b/app.json
@@ -96,7 +96,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.1.0",
+  "version": "23.2.0",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.1.0",
+  "version": "23.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.1.0",
+      "version": "23.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.1.0",
+  "version": "23.2.0",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,8 @@ sonar.projectKey=OlivierZal_com.heatzy
 sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.exclusions=**/*.png,coverage/**
+# Image CLASS guard, format-agnostic: today's store images are png, but a
+# converted or replaced asset may legitimately arrive as jpg.
+sonar.exclusions=**/*.jpg,**/*.png,coverage/**
 sonar.coverage.exclusions=tests/**,**/*.config.*,settings/**,scripts/**
 sonar.cpd.exclusions=**/*.config.*,settings/index.html


### PR DESCRIPTION
App Store release carrying the session's user-facing work: frozen forms while a change is in flight (settings sections and the credentials pair alike), the derogation end surviving a restart, credentials persisted only once the server accepts them (heatzy-api 12.0.1), divergent multi-device settings shown as undecided instead of one device's value, and the settings page reconciling itself after an app update (freshness handshake + boot poke). Also in this PR, per the release-wave directives: the settling-pass doctrine lands in CLAUDE.md (features first, then a targeted pass over each wave's own diff before release), and `**/*.jpg` returns to the Sonar exclusions as a format-agnostic image-class guard (today's store images are png; a converted asset may legitimately arrive as jpg). Flow after merge: tag v23.2.0 + GitHub release fires `publish.yml` to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3