### PR TITLE
refactor: make the gate's arming source exclusive by type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,14 @@ coverage.
   fieldsets while a request is in flight (container `disabled` +
   `aria-busy`, so a control's own domain `disabled` survives the thaw):
   every success path rewrites the fields, so a mid-flight edit would be
-  silently clobbered — pass every region `serialize` reads through
-  `fieldsetElements`. Its `serialize` must stay a PURE form snapshot, never a
-  request-body builder (reusing `buildSettingsBody` was the historical
-  never-pristine bug: it filters null deltas), and disabled greying styles
+  silently clobbered — pass every region the arming source reads through
+  `fieldsetElements`. Arming comes from exactly ONE source, exclusive by
+  type: baseline mode (`serialize`, a pure snapshot — never a
+  request-body builder: reusing `buildSettingsBody` was the historical
+  never-pristine bug, it filters null deltas) or predicate mode
+  (`isActionable`, with no baseline to retain stale form state —
+  `markSaved` then only re-evaluates); both of this app's pairs arm
+  through predicates. Disabled greying styles
   `[class*='homey-button']:disabled` generically, never a per-class list
   (a class list silently missed renamed buttons).
   `tests/unit/dirty-gate.test.ts` locks the behavior; the module is a

--- a/settings/dirty-gate.mts
+++ b/settings/dirty-gate.mts
@@ -1,11 +1,12 @@
 // The webviews' shared dirty-gating primitive: one gate owns one Apply
-// button — greyed while the form matches its saved baseline OR a request
+// button — greyed while the form is not worth submitting OR a request
 // is in flight — its sibling Refresh buttons, greyed by busy alone so
 // they stay the escape hatch on a pristine form, and the form's
 // fieldsets, frozen by busy alone: every success path rewrites the
 // fields, so an edit slipped in mid-flight would be silently clobbered
 // when the response lands — the freeze closes that window. The factory
-// owns the whole invariant; a call site only supplies `serialize`.
+// owns the whole invariant; a call site only supplies its arming source
+// (a pure snapshot or a domain predicate, exclusively).
 // Byte-identical copies of this module live in the sibling Homey apps —
 // edit them together.
 
@@ -17,17 +18,39 @@ export interface DirtyGate {
   readonly wire: (targets: readonly EventTarget[]) => void
 }
 
-export interface DirtyGateOptions {
+// Arming comes from exactly ONE source. Baseline mode: `serialize` is a
+// PURE snapshot of the form's current values — never a request-body
+// builder: those filter defaults and null deltas out, which desyncs the
+// pristine check — and Apply arms when the snapshot diverges from the
+// saved baseline. Predicate mode: when the wire protocol cannot express
+// every form divergence (an emptied field means "no instruction" and is
+// omitted from the request), supply `isActionable` instead — Apply arms
+// only when pressing it would send something, and no baseline exists to
+// retain stale form state. The pair is exclusive by type: a predicate
+// site has no use for a baseline (the predicate would short-circuit it
+// into dead weight).
+export type DirtyGateOptions = {
   readonly applyElement: HTMLButtonElement
   readonly fieldsetElements?: readonly HTMLFieldSetElement[]
   readonly refreshElements?: readonly HTMLButtonElement[]
-  readonly serialize: () => string
-  readonly isActionable?: () => boolean
-}
+} & (
+  | { readonly isActionable?: undefined; readonly serialize: () => string }
+  | { readonly serialize?: undefined; readonly isActionable: () => boolean }
+)
+
+// Predicate mode consults the domain judgment; baseline mode diffs the
+// pure snapshot against the saved baseline.
+const isArmed = (
+  options: DirtyGateOptions,
+  saved: string | undefined,
+): boolean =>
+  options.isActionable === undefined
+    ? options.serialize() !== saved
+    : options.isActionable()
 
 // `input` covers live typing in number/date fields; `change` covers the
-// selects and the final commit (and, since `serialize` reads the whole
-// form, any field a cascade handler mutated).
+// selects and the final commit (and, since the arming source reads the
+// whole form, any field a cascade handler mutated).
 const wireRecompute = (
   targets: readonly EventTarget[],
   recompute: () => void,
@@ -53,40 +76,30 @@ const setFrozen = (
   }
 }
 
-// `serialize` must be a PURE snapshot of the form's current values — never
-// a request-body builder: those filter defaults and null deltas out, which
-// desyncs the pristine check. The gate snapshots it at creation, so Apply
-// starts greyed even when no data ever loads; call `markSaved` after every
-// (re)populate and successful save, `wire` on the controls the snapshot
-// reads, and route every request through `runBusy`. When the wire
-// protocol cannot express every form divergence (an emptied field means
-// "no instruction" and is omitted from the request), supply
-// `isActionable`: Apply then arms only when pressing it would send
-// something — the arming predicate gains domain judgment while the
-// baseline bookkeeping stays the pure snapshot. Buttons grey through
-// native `disabled` (not a CSS class): it blocks keyboard activation
-// during in-flight actions and is announced by screen readers.
-export const createDirtyGate = ({
-  applyElement,
-  fieldsetElements = [],
-  isActionable,
-  refreshElements = [],
-  serialize,
-}: DirtyGateOptions): DirtyGate => {
+// The gate evaluates its arming at creation, so Apply starts greyed even
+// when no data ever loads; call `markSaved` after every (re)populate and
+// successful save (in predicate mode it only re-evaluates — there is no
+// baseline to move), `recompute` after any programmatic field write (no
+// `input` event fires for those), `wire` on the controls the arming
+// source reads, and route every request through `runBusy`. Buttons grey
+// through native `disabled` (not a CSS class): it blocks keyboard
+// activation during in-flight actions and is announced by screen
+// readers.
+export const createDirtyGate = (options: DirtyGateOptions): DirtyGate => {
+  const { applyElement, fieldsetElements = [], refreshElements = [] } = options
   let busyGeneration = 0
   let isBusy = false
-  let saved = serialize()
+  let saved = options.serialize?.()
   const recompute = (): void => {
-    applyElement.disabled =
-      isBusy || !(isActionable?.() ?? serialize() !== saved)
+    applyElement.disabled = isBusy || !isArmed(options, saved)
   }
   const markSaved = (): void => {
-    saved = serialize()
+    saved = options.serialize?.()
     recompute()
   }
   // Refresh is gated by busy ALONE (never dirty); Apply folds the busy
-  // flag into its dirty check so a mid-request edit cannot re-enable it;
-  // the fieldsets freeze and thaw with it (`setFrozen`).
+  // flag into its arming check so a mid-request edit cannot re-enable
+  // it; the fieldsets freeze and thaw with it (`setFrozen`).
   const setBusy = (isBusyNow: boolean): void => {
     isBusy = isBusyNow
     for (const element of refreshElements) {
@@ -109,9 +122,14 @@ export const createDirtyGate = ({
       }
     }
   }
-  const wire = (targets: readonly EventTarget[]): void => {
-    wireRecompute(targets, recompute)
-  }
   recompute()
-  return { markSaved, recompute, runBusy, setBusy, wire }
+  return {
+    markSaved,
+    recompute,
+    runBusy,
+    setBusy,
+    wire: (targets: readonly EventTarget[]): void => {
+      wireRecompute(targets, recompute)
+    },
+  }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -26,7 +26,7 @@
                         // fails on this device.
                         const script = document.querySelector('script[src*="index.js"]')
                         const report = (probe) => {
-                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent }, () => {})
+                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent }, () => {})
                             homey.ready()
                             homey.alert(homey.__('settings.loadFailed')).catch(() => {})
                         }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -302,28 +302,12 @@ const buildSettingsBody = ({
   return settings
 }
 
-// A stable snapshot of every common control's current value (nulls
-// included, never filtered): the dirty check compares it against the
-// value captured when the form was last populated. Sorted by id so
-// control order never perturbs the string.
-const serializeCommonSettings = (elements: PageElements): string => {
-  const entries: [string, unknown][] = []
-  for (const element of commonSettingElements(elements)) {
-    const id = settingIdOf(element)
-    if (id !== undefined) {
-      entries.push([id, processValue(element)])
-    }
-  }
-  entries.sort(([firstId], [secondId]) => firstId.localeCompare(secondId))
-  return JSON.stringify(entries)
-}
-
 const refreshCommonSettings = (context: PageContext): void => {
   const { elements, gate, state } = context
   for (const element of commonSettingElements(elements)) {
     refreshCommonSetting(element, state.flatDeviceSettings)
   }
-  // Repopulating realigns the form with the stored settings — re-baseline
+  // Repopulating realigns the form with the stored settings — re-evaluate
   // so Apply reflects the freshly pristine state.
   gate.markSaved()
 }
@@ -446,11 +430,6 @@ const createCredentialsGate = (
     isActionable: (): boolean =>
       (state.usernameElement?.value ?? '').trim() !== '' &&
       (state.passwordElement?.value ?? '') !== '',
-    serialize: (): string =>
-      JSON.stringify([
-        state.usernameElement?.value ?? '',
-        state.passwordElement?.value ?? '',
-      ]),
   })
 
 const authenticate = async (context: PageContext): Promise<void> => {
@@ -478,10 +457,9 @@ const pushLogOut = async (context: PageContext): Promise<void> => {
   if (state.passwordElement !== null) {
     state.passwordElement.value = ''
   }
-  // Re-baseline on the cleared form: the gate's saved snapshot would
-  // otherwise keep referencing the old serialized password until the
-  // page closes.
-  context.credentialsGate.markSaved()
+  // A programmatic clear fires no input event — re-evaluate by hand so
+  // sign-in greys on the emptied form.
+  context.credentialsGate.recompute()
   setAuthenticatedState(elements, false)
 }
 
@@ -557,8 +535,8 @@ const buildSections = async (context: PageContext): Promise<void> => {
   )
   await fetchDeviceSettings(context)
   generateCommonSettings(context, driverSettings)
-  // Snapshot the pristine state once the sections are built; the
-  // credentials rebaseline also re-arms sign-in for prefilled fields.
+  // Re-evaluate both gates once the sections are built; the credentials
+  // pass also re-arms sign-in for prefilled fields.
   context.gate.markSaved()
   context.credentialsGate.markSaved()
 }
@@ -615,7 +593,6 @@ const init = async (homey: HomeySettings): Promise<void> => {
       // Apply arms only when pressing it would send something.
       isActionable: (): boolean =>
         Object.keys(buildSettingsBody({ elements, state })).length > 0,
-      serialize: (): string => serializeCommonSettings(elements),
     }),
     homey,
     state,

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -123,18 +123,15 @@ describe('dirty gate', () => {
     expect(refreshElement.disabled).toBe(false)
   })
 
-  it('should arm Apply through isActionable instead of the snapshot diff', () => {
+  it('should arm Apply through isActionable with no baseline at all', () => {
     const applyElement = mock<HTMLButtonElement>({ disabled: false })
     const actionable = { value: false }
-    const form = { value: 'pristine' }
+    // Predicate mode carries NO serialize: the gate must construct and
+    // recompute without ever reaching for a snapshot.
     const gate = createDirtyGate({
       applyElement,
       isActionable: () => actionable.value,
-      serialize: () => form.value,
     })
-
-    form.value = 'edited'
-    gate.recompute()
 
     expect(applyElement.disabled).toBe(true)
 
@@ -144,6 +141,25 @@ describe('dirty gate', () => {
     expect(applyElement.disabled).toBe(false)
 
     gate.setBusy(true)
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should degrade markSaved to a re-evaluation in predicate mode', () => {
+    const applyElement = mock<HTMLButtonElement>({ disabled: false })
+    const actionable = { value: true }
+    const gate = createDirtyGate({
+      applyElement,
+      isActionable: () => actionable.value,
+    })
+
+    expect(applyElement.disabled).toBe(false)
+
+    // A successful save typically drains the predicate (the form now
+    // matches the persisted state); markSaved must pick that up even
+    // though it has no baseline to move.
+    actionable.value = false
+    gate.markSaved()
 
     expect(applyElement.disabled).toBe(true)
   })


### PR DESCRIPTION
Final twin chantier of wave B, part 2 of 3 — byte-identical propagation of OlivierZal/com.melcloud#1541 (module + test, import line aside; md5s in the wrap-up below).

Site verdicts here: BOTH pairs arm through predicates — the settings gate (`buildSettingsBody` length) and the credentials gate (both fields filled) drop their dead serializers, the orphaned `serializeCommonSettings` falls with them, the logout re-baseline (whose only real job was releasing the retained password snapshot — now impossible by construction) becomes a plain programmatic-write `recompute`, and the init comments trade baseline vocabulary for re-evaluation. Diagnostics: the inline boot beacon already carried `name: 'BootTimeout'`; its hard-coded `stack: ''` is dropped (handler types `stack?: string` and keeps accepting cached pages — not hardened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3