### PR TITLE
build: adopt configs 1.2.1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
     with:
       check-node-version: '22'
       coverage-node-version: '22'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -9,58 +9,18 @@ concurrency:
   group: claude-dependabot-fix-${{ github.event.workflow_run.head_branch }}
 jobs:
   fix:
-    # The actor gate is also the loop guard: Claude's own push re-runs CI
-    # with claude[bot] as actor, so each dependabot push gets one attempt.
-    if: |
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
-    name: Fix
     permissions:
       actions: read
       contents: read
       id-token: write
       packages: read
       pull-requests: read
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-          ref: ${{ github.event.workflow_run.head_branch }}
-      - uses: ./.github/actions/setup-node-and-install
-        with:
-          npm-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
-        with:
-          additional_permissions: |
-            actions: read
-          claude_args: --model opus
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            The `${{ github.event.workflow_run.name }}` workflow failed on the
-            dependabot branch `${{ github.event.workflow_run.head_branch }}` of
-            ${{ github.repository }} (run ${{ github.event.workflow_run.id }},
-            PR #${{ github.event.workflow_run.pull_requests[0].number }} — if
-            that number is empty, find it with `gh pr list --head` on the
-            branch). You are checked out on that branch with dependencies
-            installed.
-
-            1. Diagnose from the logs:
-               `gh run view ${{ github.event.workflow_run.id }} --log-failed`.
-            2. Reproduce locally and fix on this branch, following CLAUDE.md.
-               A bug in @olivierzal/heatzy-api is fixed there, never worked
-               around here.
-            3. Verify with the full suite: `npm run format`, `npm run lint`,
-               `npm run typecheck`, `npm test`, `npm run build`.
-            4. Only if everything passes, commit and push to this same branch
-               so CI re-runs and the existing auto-merge can complete.
-            5. If the failure is out of scope (e.g. it needs a heatzy-api
-               change), do NOT push: post one comment on the PR with the root
-               cause and the needed fix.
-    timeout-minutes: 30
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
+    with:
+      repo-guidance: 'A bug in @olivierzal/heatzy-api is fixed there, never worked around in this app.'
+      verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'
 name: Claude Dependabot Fix
 on:
   workflow_run:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: Dependabot
 on: pull_request
 permissions: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: zizmor
 on:
   merge_group: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.2.0",
+        "@olivierzal/configs": "1.2.1",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.2.0/930506e9ef448f19dd6102328de8bd084c8d1536",
-      "integrity": "sha512-06Y4mpPoePILTM+ROmwiERPlNJQyyKrpisoLZwWm9DhYyGQ1iGSy7TmaDXTCLCt+LXfepRhG2j2PXoElNhzwQA==",
+      "version": "1.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.2.1/7e651d38b234aa3d4b884729b295506b1da87358",
+      "integrity": "sha512-xYOtdvKcO+WU9tm6lv5fpsyxeqRi/p/FhbuVONb9JkdqxIa8vP/efU333EAKOpXe7TK4i+ij5hg462r3JmSw4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.2.0",
+    "@olivierzal/configs": "1.2.1",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Exact-pin bump 1.2.0 → 1.2.1 and stub refs bumped to the v1.2.1 SHA. The local claude-dependabot-fix workflow becomes the family stub: the callable's prompt already carries the exact same five-step procedure, and the doctrine line it embedded (a heatzy-api bug is fixed there, never worked around here) now travels through the new `repo-guidance` input — the reason the workflow had stayed local. The stub grants the `packages: read` the callable now declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3