### PR TITLE
build: adopt configs 1.4.0

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "::error::setup-node-and-install: 'npm-token' input is required when 'install' is 'true' (GitHub Packages auth)."
         exit 1
       shell: bash
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         # `''` is falsy in expressions, so `cond && '' || x` can never
         # yield the empty string — the condition must be inverted so

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
       actions:
         patterns:
           - '*'
+    # The workflow refs and the npm pin are one version on two channels,
+    # and a check enforces their agreement. Dependabot cannot bump both
+    # in one PR (separate ecosystems), so a lone ref bump would fail the
+    # check and deadlock against its npm twin: the npm pin drives, and
+    # the dependabot-fix run carries the refs along.
+    ignore:
+      - dependency-name: OlivierZal/configs
     package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: Audit
 on:
   push:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
     with:
       check-node-version: '22'
       coverage-node-version: '22'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
     with:
       check-node-version: '22'
       coverage-node-version: '22'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
     with:
       repo-guidance: 'A bug in @olivierzal/heatzy-api is fixed there, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,9 +17,9 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
     with:
-      repo-guidance: 'A bug in @olivierzal/heatzy-api is fixed there, never worked around in this app.'
+      repo-guidance: 'A bug in @olivierzal/heatzy-api is fixed there, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'
 name: Claude Dependabot Fix
 on:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/claude.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: Dependabot
 on: pull_request
 permissions: {}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: Dependabot
 on: pull_request
 permissions: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       packages: read
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
@@ -20,7 +20,7 @@ jobs:
       - run: cp "$NPM_CONFIG_USERCONFIG" "$GITHUB_WORKSPACE/.npmrc"
       - id: publish
         name: Publish
-        uses: athombv/github-action-homey-app-publish@0642b483f1eb66fbceb0c91b73df35d45fd2f3db
+        uses: athombv/github-action-homey-app-publish@48be66b7f2f870c22b6117d7bb84dfa06c4fc309 # v1
         with:
           personal_access_token: ${{ secrets.HOMEY_PAT }}
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           npm-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate app
-        uses: athombv/github-action-homey-app-validate@0f3b42c15d26aab79d7c48cde4d2805524da910e
+        uses: athombv/github-action-homey-app-validate@0f3b42c15d26aab79d7c48cde4d2805524da910e # untagged: master carries the `don't npm ci` fix the @typescript/native toolchain needs; v1 predates it
         with:
           level: publish
     timeout-minutes: 15

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
       packages: read
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: zizmor
 on:
   merge_group: {}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: zizmor
 on:
   merge_group: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.3.0",
+        "@olivierzal/configs": "1.3.2",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.0/63ba02ae09575a48d7b0f9a88126384fa6e3ba25",
-      "integrity": "sha512-sM500YwFYAcME61eQ9Vvh5c1Aqued7DnjSeNF+qlATcq5wzbp5ZMmWFaPhJT1Lg67yiU/3a41SZgvu64OGqfzw==",
+      "version": "1.3.2",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.2/94ed0534c00c3e137c73e8d6847b05ed8bfb16d5",
+      "integrity": "sha512-4oVJhxYUXt/14UBxXBxexDhtiqxZXK3RDEy7l12H2vFJ6QTcVKk3NHG1a7cQuAC24ykb6K4PcoHjQJQboqtEDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.3.2",
+        "@olivierzal/configs": "1.4.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.3.2",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.2/94ed0534c00c3e137c73e8d6847b05ed8bfb16d5",
-      "integrity": "sha512-4oVJhxYUXt/14UBxXBxexDhtiqxZXK3RDEy7l12H2vFJ6QTcVKk3NHG1a7cQuAC24ykb6K4PcoHjQJQboqtEDw==",
+      "version": "1.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.4.0/07e9e8d271a240cd92725d86d7a7b2519954032f",
+      "integrity": "sha512-arD6N/2vLTTz7AWE228fZR1EP3AFUa21i4xmATGBGhRbpXDySbsxE0cQVjMpbLXXqlqXzPgQztp55frwM/mF/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.3.2",
+    "@olivierzal/configs": "1.4.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.3.0",
+    "@olivierzal/configs": "1.3.2",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Pins the npm package and every workflow ref to 1.4.0, and gives each SHA-pinned `uses:` a version comment the release's pin check verifies against the upstream — resolved here, never assumed: `actions/checkout` is v7.0.1 and `actions/setup-node` is v6.4.0.

Two Athom actions were pinned to `master` HEAD, which carries no tag, so no `# v…` beside them could have been true. They are handled differently because the evidence differs. `homey-app-publish` is re-pinned to the commit `v1` names: its v1→master delta is `README.md` alone (+4/-4, compared file by file), so the job is unchanged in substance and the comment is now honest. `homey-app-validate` keeps its commit and carries the release's new `# untagged:` form instead: re-pinning it to v1 was tried and refuted by CI on the sibling app, where `Validate app` failed with `Tsconfig validation failed: unable to read configuration from npx tsc --showConfig` — master's `don't npm ci` commit is what makes the action work with the @typescript/native toolchain, and v1 predates it.

`OlivierZal/configs` leaves the github-actions ecosystem in `dependabot.yml`: the workflow refs and the npm pin are one version on two channels and the check enforces their agreement, but Dependabot cannot bump both in one pull request, so a lone ref bump would deadlock against its npm twin. The npm pin drives; the dependabot-fix guidance now tells the fixer to carry the refs along — and to stop for human review when the release changes lint policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3