### PR TITLE
chore(release): 23.2.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -62,5 +62,9 @@
   "23.2.0": {
     "en": "The settings page now locks its forms while a change is being applied, refreshes itself after an app update, and shows a setting as undecided when your devices disagree instead of picking one of them. Your credentials are saved only once signing in succeeds, and a running derogation keeps its end time across a restart.",
     "fr": "La page de réglages fige désormais ses formulaires pendant l'application d'un changement, se met à jour d'elle-même après une mise à jour de l'app, et affiche un réglage comme indéterminé lorsque vos appareils divergent au lieu d'en choisir un. Vos identifiants ne sont enregistrés qu'une fois la connexion réussie, et une dérogation en cours conserve son heure de fin après un redémarrage."
+  },
+  "23.2.1": {
+    "en": "A settings page left open on your phone now refreshes itself when you come back to it after an app update, instead of staying on the previous version.",
+    "fr": "Une page de réglages laissée ouverte sur votre téléphone se met désormais à jour lorsque vous y revenez après une mise à jour de l'app, au lieu de rester sur la version précédente."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -95,5 +95,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.2.0"
+  "version": "23.2.1"
 }

--- a/app.json
+++ b/app.json
@@ -96,7 +96,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.2.0",
+  "version": "23.2.1",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.2.0",
+  "version": "23.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.2.0",
+      "version": "23.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.2.0",
+  "version": "23.2.1",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {


### PR DESCRIPTION
Patch release. The only user-visible change: a settings page left open on a phone now refreshes itself when the user returns to it after an app update, instead of staying on the previous version — the realtime poke it relied on is emitted while every open page is disconnected by the very restart that triggers it, so a surviving webview never re-checked. Everything else in this release is internal (shared tooling and runtime packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3