### PR TITLE
test: bring the settings page under the real coverage bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "esbuild": "^0.28.1",
         "eslint": "^10.8.0",
+        "happy-dom": "20.11.2",
         "homey-apps-sdk-v3-types": "^0.3.12",
         "jiti": "^2.7.0",
         "prettier": "^3.9.6",
@@ -1963,6 +1964,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
@@ -3254,6 +3272,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
@@ -4385,6 +4416,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.2.tgz",
+      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/has-flag": {
@@ -7482,6 +7545,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7523,6 +7596,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "esbuild": "^0.28.1",
     "eslint": "^10.8.0",
+    "happy-dom": "20.11.2",
     "homey-apps-sdk-v3-types": "^0.3.12",
     "jiti": "^2.7.0",
     "prettier": "^3.9.6",

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -123,14 +123,18 @@ const reportFreshness = (homey: HomeySettings, message: string): void => {
   )
 }
 
+// Iterates every element so the `undefined` narrow is a real branch: a
+// `[data-i18n]` selector would guarantee the attribute and leave the
+// guard as dead code under the 100% coverage bar.
 const translatePage = (homey: HomeySettings): void => {
-  for (const element of document.querySelectorAll<HTMLElement>('[data-i18n]')) {
+  for (const element of document.querySelectorAll<HTMLElement>('*')) {
     const key = element.dataset.i18n
-    if (key !== undefined) {
-      const translation = homey.__(key)
-      if (translation !== '' && translation !== key) {
-        element.textContent = translation
-      }
+    if (key === undefined) {
+      continue
+    }
+    const translation = homey.__(key)
+    if (translation !== '' && translation !== key) {
+      element.textContent = translation
     }
   }
 }
@@ -166,8 +170,10 @@ const flattenDeviceSettings = (
   return flat
 }
 
+// Identity rides `dataset`, never an encoded id: splitting an id on a
+// separator breaks the day a setting id contains it (com.melcloud form).
 const settingIdOf = (element: HTMLSelectElement): string | undefined =>
-  element.id.split('__', 1)[0]
+  element.dataset.settingId
 
 const refreshCommonSetting = (
   element: HTMLSelectElement,
@@ -209,6 +215,12 @@ const processValue = (element: HTMLSelectElement): unknown => {
   return null
 }
 
+// The select displays a number as its string (refreshCommonSetting), so
+// the divergence check must compare against the same view — comparing
+// the raw number would arm Apply forever on an untouched form.
+const matchesBaseline = (value: unknown, baseline: unknown): boolean =>
+  value === (typeof baseline === 'number' ? String(baseline) : baseline)
+
 const buildSettingsBody = ({
   elements,
   state,
@@ -221,7 +233,7 @@ const buildSettingsBody = ({
       id !== undefined &&
       value !== null &&
       (state.flatDeviceSettings[id] === null ||
-        value !== state.flatDeviceSettings[id])
+        !matchesBaseline(value, state.flatDeviceSettings[id]))
     ) {
       settings[id] = value
     }
@@ -241,10 +253,8 @@ const refreshCommonSettings = (context: PageContext): void => {
 
 const updateDeviceSettings = (state: PageState, body: Settings): void => {
   for (const [id, value] of Object.entries(body)) {
-    for (const driver of Object.keys(state.deviceSettings)) {
-      const driverSettings = state.deviceSettings[driver] ?? {}
+    for (const driverSettings of Object.values(state.deviceSettings)) {
       driverSettings[id] = value
-      state.deviceSettings[driver] = driverSettings
     }
     state.flatDeviceSettings[id] = value
   }
@@ -306,18 +316,22 @@ const generateCommonSettings = (
   const { elements, homey, state } = context
   const optionSettings = driverSettings.options ?? []
   for (const { id, title, type, values } of optionSettings) {
-    const settingId = `${id}__settings`
-    if (commonElementTypes.has(type)) {
-      const valueElement = createSelect(
-        settingId,
-        values ?? booleanOptions((key) => homey.__(key)),
-        'homey-form-select',
-      )
-      // Every control feeds the dirty check that gates Apply.
-      context.gate.wire([valueElement])
-      createGroupElement(elements.settingsCommon, valueElement, title)
-      refreshCommonSetting(valueElement, state.flatDeviceSettings)
+    if (!commonElementTypes.has(type)) {
+      continue
     }
+
+    // The DOM id (label linkage) stays suffixed to avoid colliding
+    // with the page's own ids; the setting identity rides `dataset`.
+    const valueElement = createSelect(
+      `${id}__settings`,
+      values ?? booleanOptions((key) => homey.__(key)),
+      'homey-form-select',
+    )
+    valueElement.dataset.settingId = id
+    // Every control feeds the dirty check that gates Apply.
+    context.gate.wire([valueElement])
+    createGroupElement(elements.settingsCommon, valueElement, title)
+    refreshCommonSetting(valueElement, state.flatDeviceSettings)
   }
 }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,5 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 # Image CLASS guard, format-agnostic: today's store images are png, but a
 # converted or replaced asset may legitimately arrive as jpg.
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,settings/**,scripts/**
+sonar.coverage.exclusions=tests/**,**/*.config.*,scripts/**
 sonar.cpd.exclusions=**/*.config.*,settings/index.html

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -1,0 +1,630 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import { readFileSync } from 'node:fs'
+
+import type { DriverSetting } from '@olivierzal/homey-kit/manifest'
+import type HomeySettings from 'homey/lib/HomeySettings'
+import {
+  getButton,
+  getDetails,
+  getFieldset,
+  getInput,
+} from '@olivierzal/homey-kit/dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DeviceSettings } from '../../types/device-settings.mts'
+import { start } from '../../settings/index.mts'
+import { mock, settleDetached } from '../helpers.ts'
+
+// A plain relative path: under the happy-dom environment
+// `import.meta.url` is an http URL the fs module refuses.
+const pageHtml = readFileSync('settings/index.html', 'utf8')
+
+type ApiCallback = (error: Error | null, result: unknown) => void
+
+interface Harness {
+  readonly alert: ReturnType<typeof vi.fn>
+  readonly api: ReturnType<typeof vi.fn>
+  readonly homey: HomeySettings
+  readonly ready: ReturnType<typeof vi.fn>
+  readonly routes: Record<string, unknown>
+  readonly emit: (event: string) => void
+}
+
+interface HomeyOptions {
+  readonly confirmError?: Error | null
+  readonly failures?: Readonly<Record<string, Error>>
+  readonly isConfirmed?: boolean
+  readonly routes?: Record<string, unknown>
+  readonly shouldRejectAlerts?: boolean
+  readonly storedCredentials?: Record<string, unknown> | null
+  readonly storedError?: Error | null
+  readonly translations?: Readonly<Record<string, string>>
+}
+
+const driverSettingsFixture = (): Partial<Record<string, DriverSetting[]>> => ({
+  login: [
+    {
+      driverId: 'heatzy',
+      driverLabel: 'Heatzy',
+      groupId: 'login',
+      id: 'username',
+      placeholder: 'user@example.com',
+      title: 'Email',
+      type: 'text',
+    },
+    {
+      driverId: 'heatzy',
+      driverLabel: 'Heatzy',
+      groupId: 'login',
+      id: 'password',
+      title: 'Password',
+      type: 'password',
+    },
+  ],
+  options: [
+    {
+      driverId: 'heatzy',
+      driverLabel: 'Heatzy',
+      id: 'always_on',
+      title: 'Always on',
+      type: 'checkbox',
+    },
+    {
+      driverId: 'heatzy',
+      driverLabel: 'Heatzy',
+      id: 'on_mode',
+      title: 'On mode',
+      type: 'dropdown',
+      values: [
+        { id: 'previous', label: 'Previous' },
+        { id: 'cft', label: 'Comfort' },
+      ],
+    },
+    {
+      driverId: 'heatzy',
+      driverLabel: 'Heatzy',
+      id: 'temp_limit',
+      title: 'Temperature limit',
+      type: 'dropdown',
+      values: [
+        { id: '15', label: '15' },
+        { id: '16', label: '16' },
+      ],
+    },
+    {
+      driverId: 'heatzy',
+      driverLabel: 'Heatzy',
+      id: 'notes',
+      title: 'Notes',
+      type: 'label',
+    },
+  ],
+})
+
+const deviceSettingsFixture = (): DeviceSettings => ({
+  glow: { always_on: true, on_mode: 'cft', temp_limit: 15 },
+  heatzy: { always_on: true, on_mode: 'previous', temp_limit: 15 },
+})
+
+// The SDK api overloads GET/DELETE (3 args) with POST/PUT (4): the mock
+// mirrors that shape through a rest tuple and picks the trailing
+// callback, whichever slot it landed in.
+type ApiCallArgs = readonly [string, string, ...unknown[]]
+
+const createApiMock = (
+  failures: Readonly<Record<string, Error>>,
+  routes: Record<string, unknown>,
+): ReturnType<typeof vi.fn> =>
+  vi.fn<(...callArgs: ApiCallArgs) => void>((...callArgs) => {
+    const [method, path] = callArgs
+    const callback = callArgs.findLast(
+      (argument): argument is ApiCallback => typeof argument === 'function',
+    )
+    const key = `${method} ${path}`
+    const failure = failures[key]
+    if (failure === undefined) {
+      callback?.(null, routes[key])
+      return
+    }
+    callback?.(failure, null)
+  })
+
+const createAlertMock = (
+  shouldRejectAlerts: boolean,
+): ReturnType<typeof vi.fn<() => Promise<void>>> =>
+  shouldRejectAlerts
+    ? vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(new Error('alert channel down'))
+    : vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+const createHarness = (options: HomeyOptions = {}): Harness => {
+  const {
+    confirmError = null,
+    failures = {},
+    isConfirmed = true,
+    routes = {},
+    shouldRejectAlerts = false,
+    storedCredentials = {},
+    storedError = null,
+    translations = {},
+  } = options
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>()
+  const api = createApiMock(failures, routes)
+  const alert = createAlertMock(shouldRejectAlerts)
+  const ready = vi.fn<() => void>()
+  const homey = mock<HomeySettings>({
+    alert,
+    api,
+    ready,
+    __: (key: string): string => translations[key] ?? key,
+    confirm: (
+      _message: string,
+      _icon: string | null,
+      callback: (error: Error | null, result: boolean) => void,
+    ): void => {
+      callback(confirmError, isConfirmed)
+    },
+    get: (callback: (error: Error | null, settings: unknown) => void): void => {
+      callback(storedError, storedCredentials)
+    },
+    on: (event: string, listener: (...args: unknown[]) => void): void => {
+      const bucket = listeners.get(event) ?? []
+      bucket.push(listener)
+      listeners.set(event, bucket)
+    },
+  })
+  return {
+    alert,
+    api,
+    homey,
+    ready,
+    routes,
+    emit: (event: string): void => {
+      const bucket = listeners.get(event)
+      if (bucket !== undefined) {
+        for (const listener of bucket) {
+          listener()
+        }
+      }
+    },
+  }
+}
+
+const defaultRoutes = (): Record<string, unknown> => ({
+  'DELETE /sessions': undefined,
+  'GET /language': 'fr',
+  'GET /sessions': true,
+  'GET /settings/devices': deviceSettingsFixture(),
+  'GET /settings/drivers': driverSettingsFixture(),
+  'GET /webview-hashes': {},
+  'POST /boot-error': undefined,
+  'POST /sessions': undefined,
+  'PUT /settings/devices': undefined,
+})
+
+const bootPage = async (options: HomeyOptions = {}): Promise<Harness> => {
+  const harness = createHarness({ routes: defaultRoutes(), ...options })
+  start(harness.homey)
+  await settleDetached()
+  await settleDetached()
+  return harness
+}
+
+const settingSelect = (settingId: string): HTMLSelectElement => {
+  const element = document.querySelector(
+    `select[data-setting-id="${CSS.escape(settingId)}"]`,
+  )
+  if (element instanceof HTMLSelectElement) {
+    return element
+  }
+  throw new TypeError(`No generated select for setting \`${settingId}\``)
+}
+
+interface HTMLValueElementLike extends HTMLElement {
+  value: string
+}
+
+const commit = (element: HTMLValueElementLike, value: string): void => {
+  element.value = value
+  element.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+const applyButton = (): HTMLButtonElement => getButton('apply_settings_common')
+
+const authenticateButton = (): HTMLButtonElement => getButton('authenticate')
+
+const resetButton = (): HTMLButtonElement => getButton('reset_credentials')
+
+const devicesFieldset = (): HTMLFieldSetElement => getFieldset('devices')
+
+const authenticationDetails = (): HTMLDetailsElement =>
+  getDetails('authentication')
+
+// DOMParser never executes scripts, which is exactly why it is the
+// sanctioned way to load the real page into the simulated DOM; appended
+// nodes are auto-adopted across documents.
+const loadPage = (): void => {
+  const parser = new DOMParser()
+  const parsed = parser.parseFromString(pageHtml, 'text/html')
+  document.head.replaceChildren(...parsed.head.children)
+  document.body.replaceChildren(...parsed.body.children)
+}
+
+describe('settings page', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    loadPage()
+    document.documentElement.lang = 'en'
+  })
+
+  describe('boot', () => {
+    it('should build every section from the fixtures', async () => {
+      const { ready } = await bootPage({
+        storedCredentials: { username: 'stored@example.com' },
+      })
+
+      expect(ready).toHaveBeenCalledTimes(1)
+      expect(document.documentElement.lang).toBe('fr')
+
+      const username = getInput('username')
+
+      expect(username.value).toBe('stored@example.com')
+      expect(username.autocomplete).toBe('username')
+      expect(username.autocapitalize).toBe('none')
+      expect(username.placeholder).toBe('user@example.com')
+
+      const password = getInput('password')
+
+      expect(password.value).toBe('')
+      expect(password.autocomplete).toBe('current-password')
+      expect(settingSelect('always_on').value).toBe('true')
+      expect(settingSelect('on_mode').value).toBe('')
+      expect(settingSelect('temp_limit').value).toBe('15')
+      expect(settingSelect('always_on').id).toBe('always_on__settings')
+      expect(
+        document.querySelector('select[data-setting-id="notes"]'),
+      ).toBeNull()
+      expect(devicesFieldset().hidden).toBe(false)
+      expect(authenticationDetails().open).toBe(false)
+      expect(applyButton().disabled).toBe(true)
+    })
+
+    it('should stay signed out when the session read says so', async () => {
+      await bootPage({ routes: { ...defaultRoutes(), 'GET /sessions': false } })
+
+      expect(devicesFieldset().hidden).toBe(true)
+      expect(authenticationDetails().open).toBe(true)
+    })
+
+    it('should keep the authored language when the read fails', async () => {
+      await bootPage({ failures: { 'GET /language': new Error('offline') } })
+
+      expect(document.documentElement.lang).toBe('en')
+    })
+
+    it('should translate keys and skip empty or echoed translations', async () => {
+      await bootPage({
+        translations: {
+          'settings.authenticate.legend': '',
+          'settings.title': 'Réglages Heatzy',
+        },
+      })
+
+      expect(document.querySelector('.homey-title')?.textContent).toBe(
+        'Réglages Heatzy',
+      )
+      expect(
+        document.querySelector('[data-i18n="settings.authenticate.legend"]')
+          ?.textContent,
+      ).toBe('Credentials')
+      expect(
+        document.querySelector('[data-i18n="settings.update"]')?.textContent,
+      ).toBe('Update')
+    })
+
+    it('should alert after the overlay when the build fails', async () => {
+      const { alert, ready } = await bootPage({
+        failures: { 'GET /settings/drivers': new Error('boom') },
+      })
+
+      expect(ready).toHaveBeenCalledTimes(1)
+      expect(alert).toHaveBeenCalledWith('boom')
+    })
+
+    it('should swallow a failing alert channel', async () => {
+      const { alert } = await bootPage({
+        failures: { 'GET /settings/drivers': new Error('boom') },
+        shouldRejectAlerts: true,
+      })
+
+      expect(alert).toHaveBeenCalledWith('boom')
+    })
+
+    it('should leave the fields empty when the stored read errors', async () => {
+      await bootPage({ storedError: new Error('storage down') })
+
+      expect(getInput('username').value).toBe('')
+    })
+
+    it('should leave the fields empty when nothing is stored', async () => {
+      await bootPage({ storedCredentials: null })
+
+      expect(getInput('username').value).toBe('')
+    })
+  })
+
+  describe('device settings form', () => {
+    it('should arm Apply on a divergence and disarm on revert', async () => {
+      await bootPage()
+
+      commit(settingSelect('always_on'), 'false')
+
+      expect(applyButton().disabled).toBe(false)
+
+      commit(settingSelect('always_on'), 'true')
+
+      expect(applyButton().disabled).toBe(true)
+    })
+
+    it('should push the changed values and rebase the form', async () => {
+      const { alert, api } = await bootPage({
+        translations: { 'settings.success': 'Enregistré' },
+      })
+
+      commit(settingSelect('always_on'), 'false')
+      commit(settingSelect('on_mode'), 'previous')
+      applyButton().click()
+      await settleDetached()
+
+      expect(api).toHaveBeenCalledWith(
+        'PUT',
+        '/settings/devices',
+        { always_on: false, on_mode: 'previous' },
+        expect.any(Function),
+      )
+      expect(alert).toHaveBeenCalledWith('Enregistré')
+      expect(applyButton().disabled).toBe(true)
+
+      commit(settingSelect('always_on'), 'false')
+
+      expect(applyButton().disabled).toBe(true)
+    })
+
+    it('should alert and keep the baseline when the push fails', async () => {
+      const { alert } = await bootPage({
+        failures: { 'PUT /settings/devices': new Error('offline') },
+      })
+
+      commit(settingSelect('always_on'), 'false')
+      applyButton().click()
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('offline')
+      expect(applyButton().disabled).toBe(false)
+    })
+
+    it('should realign the form on Refresh', async () => {
+      await bootPage()
+
+      commit(settingSelect('always_on'), 'false')
+      const refresh = getButton('refresh_settings_common')
+      refresh.click()
+
+      expect(settingSelect('always_on').value).toBe('true')
+      expect(applyButton().disabled).toBe(true)
+    })
+
+    it('should refresh the grouped values on a device update', async () => {
+      const { emit, routes } = await bootPage()
+
+      routes['GET /settings/devices'] = {
+        glow: { always_on: false, on_mode: 'cft' },
+        heatzy: { always_on: false, on_mode: 'cft' },
+      }
+      emit('deviceupdate')
+      await settleDetached()
+
+      expect(settingSelect('always_on').value).toBe('false')
+      expect(settingSelect('on_mode').value).toBe('cft')
+    })
+
+    it('should ignore a select it did not build', async () => {
+      await bootPage()
+
+      const rogue = document.createElement('select')
+      const option = document.createElement('option')
+      option.value = 'x'
+      rogue.append(option)
+      document.querySelector('#settings_common')?.append(rogue)
+      commit(rogue, 'x')
+
+      expect(applyButton().disabled).toBe(true)
+
+      const refresh = getButton('refresh_settings_common')
+      refresh.click()
+
+      expect(rogue.value).toBe('x')
+    })
+  })
+
+  describe('credentials', () => {
+    it('should sign in with the trimmed credentials', async () => {
+      const { api } = await bootPage({
+        routes: { ...defaultRoutes(), 'GET /sessions': false },
+      })
+
+      commit(getInput('username'), ' user@example.com ')
+      commit(getInput('password'), 'secret')
+
+      expect(authenticateButton().disabled).toBe(false)
+
+      authenticateButton().click()
+      await settleDetached()
+
+      expect(api).toHaveBeenCalledWith(
+        'POST',
+        '/sessions',
+        { password: 'secret', username: 'user@example.com' },
+        expect.any(Function),
+      )
+      expect(authenticationDetails().open).toBe(false)
+      expect(devicesFieldset().hidden).toBe(false)
+    })
+
+    it('should alert instead of posting an emptied credential', async () => {
+      const { alert, api } = await bootPage({
+        routes: { ...defaultRoutes(), 'GET /sessions': false },
+        translations: { 'settings.authenticate.failure': 'Échec' },
+      })
+
+      commit(getInput('username'), 'user@example.com')
+      commit(getInput('password'), 'secret')
+      // A programmatic clear fires no input event, so Sign in stays armed.
+      getInput('username').value = ''
+      authenticateButton().click()
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('Échec')
+      expect(api).not.toHaveBeenCalledWith(
+        'POST',
+        '/sessions',
+        expect.anything(),
+        expect.any(Function),
+      )
+    })
+
+    it('should alert when the sign-in fails', async () => {
+      const { alert } = await bootPage({
+        failures: { 'POST /sessions': new Error('bad credentials') },
+        routes: { ...defaultRoutes(), 'GET /sessions': false },
+      })
+
+      commit(getInput('username'), 'user@example.com')
+      commit(getInput('password'), 'wrong')
+      authenticateButton().click()
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('bad credentials')
+      expect(authenticationDetails().open).toBe(true)
+    })
+
+    it('should do nothing when the reset is not confirmed', async () => {
+      const { api } = await bootPage({ isConfirmed: false })
+
+      resetButton().click()
+      await settleDetached()
+
+      expect(api).not.toHaveBeenCalledWith(
+        'DELETE',
+        '/sessions',
+        expect.any(Function),
+      )
+    })
+
+    it('should sign out, clear the password and fold the devices', async () => {
+      await bootPage({ storedCredentials: { password: 'secret' } })
+
+      expect(getInput('password').value).toBe('secret')
+
+      resetButton().click()
+      await settleDetached()
+
+      expect(getInput('password').value).toBe('')
+      expect(devicesFieldset().hidden).toBe(true)
+      expect(authenticationDetails().open).toBe(true)
+    })
+
+    it('should alert and keep the password when the sign-out fails', async () => {
+      const { alert } = await bootPage({
+        failures: { 'DELETE /sessions': new Error('offline') },
+        storedCredentials: { password: 'secret' },
+      })
+
+      resetButton().click()
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('offline')
+      expect(getInput('password').value).toBe('secret')
+    })
+
+    it('should alert when the confirmation channel errors', async () => {
+      const { alert } = await bootPage({
+        confirmError: new Error('dialog down'),
+      })
+
+      resetButton().click()
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('dialog down')
+    })
+
+    it('should keep sign-in greyed when the password field is missing', async () => {
+      const settings = driverSettingsFixture()
+      settings.login = settings.login?.filter(({ id }) => id === 'username')
+      await bootPage({
+        routes: { ...defaultRoutes(), 'GET /settings/drivers': settings },
+      })
+
+      expect(document.querySelector('#password')).toBeNull()
+
+      commit(getInput('username'), 'user@example.com')
+
+      expect(authenticateButton().disabled).toBe(true)
+
+      resetButton().click()
+      await settleDetached()
+
+      expect(devicesFieldset().hidden).toBe(true)
+    })
+
+    it('should build no credential fields without a login group', async () => {
+      const settings = driverSettingsFixture()
+      delete settings.login
+      delete settings.options
+      const { alert } = await bootPage({
+        routes: { ...defaultRoutes(), 'GET /settings/drivers': settings },
+        translations: { 'settings.authenticate.failure': 'Échec' },
+      })
+
+      expect(document.querySelector('#username')).toBeNull()
+      expect(document.querySelector('#password')).toBeNull()
+
+      // The gate keeps the button greyed, but the listener itself must
+      // still refuse a credential-less submit: dispatch past `disabled`.
+      authenticateButton().dispatchEvent(new Event('click'))
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('Échec')
+    })
+  })
+
+  describe('freshness', () => {
+    it('should refetch a stale page and skip the build', async () => {
+      const stamped = document.createElement('link')
+      stamped.setAttribute('href', 'index.css?v=aaaa1111')
+      document.head.append(stamped)
+      const { api, ready } = await bootPage({
+        routes: {
+          ...defaultRoutes(),
+          'GET /webview-hashes': { settings: 'bbbb2222' },
+        },
+      })
+
+      expect(ready).toHaveBeenCalledTimes(1)
+      expect(api).toHaveBeenCalledWith(
+        'POST',
+        '/boot-error',
+        expect.objectContaining({ name: 'WebviewFreshness' }),
+        expect.any(Function),
+      )
+      expect(api).not.toHaveBeenCalledWith(
+        'GET',
+        '/settings/drivers',
+        expect.any(Function),
+      )
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ const config: ViteUserConfig = defineConfig({
   plugins: [swcPlugin],
   test: {
     coverage: {
-      exclude: ['.homeybuild/**', 'scripts/**/*.mts', 'settings/**/*.mts'],
+      exclude: ['.homeybuild/**', 'scripts/**/*.mts'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
The 100% coverage figure excluded `settings/**` from both vitest and Sonar — the whole settings page (~600 lines) had never run under a test; real coverage was 60.4% (309/512 statements). This lifts both exclusions and brings the page to a true 100% (514/514 statements, 207/207 branches, 176/176 functions) through a happy-dom harness that loads the real `settings/index.html` via DOMParser, drives the real kit primitives (dirty-gate, freshness, boot cycle, DOM builders), and mocks only the SDK boundary.

Two debts fixed along the way, both surfaced by the tests:
- **Control identity now rides `dataset.settingId`** instead of splitting the DOM id on `__` — the encoded id broke the day a setting id contained the separator (com.melcloud form).
- **A latent display/compare asymmetry**: `refreshCommonSetting` renders a numeric stored value as its string, but `buildSettingsBody` compared the select's string against the raw number — a numeric setting would have armed Apply forever on an untouched form. The divergence check now compares against the displayed view. Latent today (Heatzy ships no numeric setting), real the day one arrives.

Also rewrites two dead branches the bar rightly rejects (`?? {}` on always-defined lookups, an unreachable `undefined` guard under a `[data-i18n]` selector), and adds `happy-dom` (exact pin) with per-file `@vitest-environment` docblocks, the homey-kit form.

No version bump, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3