### PR TITLE
fix: parse on Homey Pro 2016-2019 and log the platform split

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -260,7 +260,17 @@ export default class HeatzyApp extends App {
 
   async #logBootReady(): Promise<void> {
     await this.homey.ready()
-    this.log('Boot: ready after', process.uptime().toFixed(1), 's')
+    // Measurement breadcrumb (2026-08): the installed base's platform
+    // split (1 = Homey Pro 2016-2019, 2 = Pro 2023+) decides the node
+    // device-floor policy — read it from diagnostics reports.
+    this.log(
+      'Boot: ready after',
+      process.uptime().toFixed(1),
+      's — platform',
+      this.homey.platformVersion ?? 'unknown',
+      '— node',
+      process.version,
+    )
   }
 
   // User-facing half of heatzy-api's onAuthenticationLost contract:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "23.2.2",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/heatzy-api": "12.0.1",
+        "@olivierzal/heatzy-api": "12.0.2",
         "@olivierzal/homey-kit": "3.1.0",
         "source-map-support": "^0.5.21"
       },
@@ -1098,9 +1098,9 @@
       }
     },
     "node_modules/@olivierzal/heatzy-api": {
-      "version": "12.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/12.0.1/157e46babbac311747141f0a760a1b85971d52a0",
-      "integrity": "sha512-u/Il0epm+1av5FB/YvZigRxnyqHAgwuCmbytzPMvEKXV+/FqlxN1A/jexRB2sDmz73L1AALP6ZFGEE6em4ppfw==",
+      "version": "12.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/heatzy-api/12.0.2/eb532ebc958f1b154b53136fbb6be601b4857b34",
+      "integrity": "sha512-ZZLIy3UCXk178LEQz5JAiT189gz+N/F/gOYTORh2GaSOROmfsmcmqsmNF/6sE1ST+egeq96PMWpK/r0wlMR/7Q==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/heatzy-api": "12.0.1",
+    "@olivierzal/heatzy-api": "12.0.2",
     "@olivierzal/homey-kit": "3.1.0",
     "source-map-support": "^0.5.21"
   },

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -320,7 +320,10 @@ describe(HeatzyApp, () => {
       expect(app.log).toHaveBeenCalledWith(
         'Boot: ready after',
         expect.any(String),
-        's',
+        's — platform',
+        expect.anything(),
+        '— node',
+        process.version,
       )
     })
 


### PR DESCRIPTION
Two moves, mirroring com.melcloud#1556:

- **heatzy-api 12.0.2** (exact pin): its one shipped `v`-flag regex moves to `u` — a parse-time `SyntaxError` on Node < 20 that killed this app at boot on Homey Pro 2016-2019 (its compound `iv` form had escaped the first diagnosis).
- **Measurement breadcrumb**: the boot-ready log line now carries `homey.platformVersion` and `process.version`, so diagnostics reports show the installed-base split the pending node device-floor decision needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3