### PR TITLE
chore(release): 23.3.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -90,5 +90,9 @@
   "23.2.2": {
     "en": "The app no longer installs a large set of development files it never needed, freeing space on your Homey and removing a reported vulnerability along with them.",
     "fr": "L’app n’installe plus un vaste ensemble de fichiers de développement dont elle n’avait aucun besoin, ce qui libère de l’espace sur votre Homey et supprime au passage une vulnérabilité signalée."
+  },
+  "23.3.0": {
+    "en": "Fixes the app failing to start on Homey Pro (2016 – 2019).",
+    "fr": "Corrige l'impossibilité de démarrer l'app sur Homey Pro (2016 – 2019)."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -95,5 +95,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.2.2"
+  "version": "23.3.0"
 }

--- a/app.json
+++ b/app.json
@@ -96,7 +96,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.2.2",
+  "version": "23.3.0",
   "flow": {
     "triggers": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.2.2",
+  "version": "23.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.2.2",
+      "version": "23.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.2.2",
+  "version": "23.3.0",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {


### PR DESCRIPTION
Store release: the app starts again on Homey Pro (2016 – 2019) — the library's shipped es2024 `v`-flag regex was a parse-time SyntaxError on its Node < 20 runtime. Also carries the skipped-version notifications, the rewritten changelog, the real settings-page coverage and the platform-split measurement breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3