### PR TITLE
chore(release): 23.3.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -91,8 +91,8 @@
     "en": "The app no longer installs a large set of development files it never needed, freeing space on your Homey and removing a reported vulnerability along with them.",
     "fr": "L’app n’installe plus un vaste ensemble de fichiers de développement dont elle n’avait aucun besoin, ce qui libère de l’espace sur votre Homey et supprime au passage une vulnérabilité signalée."
   },
-  "23.3.0": {
-    "en": "Fixes the app failing to start on Homey Pro (2016 – 2019).",
-    "fr": "Corrige l'impossibilité de démarrer l'app sur Homey Pro (2016 – 2019)."
+  "23.3.1": {
+    "en": "Fixes the app failing to start on Homey Pro (2016 – 2019) running older firmware.",
+    "fr": "Corrige l'impossibilité de démarrer l'app sur Homey Pro (2016 – 2019) sous un firmware ancien."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -95,5 +95,5 @@
       "sèche serviette"
     ]
   },
-  "version": "23.3.0"
+  "version": "23.3.1"
 }

--- a/app.json
+++ b/app.json
@@ -96,7 +96,7 @@
       "sèche serviette"
     ]
   },
-  "version": "23.3.0",
+  "version": "23.3.1",
   "flow": {
     "triggers": [
       {

--- a/app.mts
+++ b/app.mts
@@ -260,17 +260,7 @@ export default class HeatzyApp extends App {
 
   async #logBootReady(): Promise<void> {
     await this.homey.ready()
-    // Measurement breadcrumb (2026-08): the installed base's platform
-    // split (1 = Homey Pro 2016-2019, 2 = Pro 2023+) decides the node
-    // device-floor policy — read it from diagnostics reports.
-    this.log(
-      'Boot: ready after',
-      process.uptime().toFixed(1),
-      's — platform',
-      this.homey.platformVersion ?? 'unknown',
-      '— node',
-      process.version,
-    )
+    this.log('Boot: ready after', process.uptime().toFixed(1), 's')
   }
 
   // User-facing half of heatzy-api's onAuthenticationLost contract:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.heatzy",
-  "version": "23.3.0",
+  "version": "23.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.heatzy",
-      "version": "23.3.0",
+      "version": "23.3.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/heatzy-api": "12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.heatzy",
-  "version": "23.3.0",
+  "version": "23.3.1",
   "description": "Heatzy for Homey",
   "homepage": "https://github.com/OlivierZal/com.heatzy/",
   "bugs": {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -320,10 +320,7 @@ describe(HeatzyApp, () => {
       expect(app.log).toHaveBeenCalledWith(
         'Boot: ready after',
         expect.any(String),
-        's — platform',
-        expect.anything(),
-        '— node',
-        process.version,
+        's',
       )
     })
 


### PR DESCRIPTION
Final-scope release replacing the never-promoted 23.3.0 (tag kept as an honest trace, changelog entry moved here). Drops the measurement breadcrumb per the product decision. Changelog: the app starts again on Homey Pro (2016 – 2019) running older firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3