### PR TITLE
test(scripts): cover the bundler and drop the scripts sweep

### DIFF
--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -32,6 +32,10 @@ const REFERENCE =
   /(?<prefix>href="|src=")(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>")/gv
 
 const sharedOptions: BuildOptions = {
+  // Pinned at load: esbuild's service process outlives this module and
+  // keeps its own working directory, so relative entries must be
+  // anchored to the app root explicitly.
+  absWorkingDir: process.cwd(),
   bundle: true,
   legalComments: 'none',
   logLevel: 'info',
@@ -85,26 +89,42 @@ const hashOf = async (filePath: string): Promise<string> => {
     .slice(0, HASH_LENGTH)
 }
 
-const collectHashes = async (
+interface StampedReference {
+  readonly hash: string
+  readonly index: number
+  readonly length: number
+  readonly text: string
+}
+
+// Every alternative of `REFERENCE` binds all three named groups with at
+// least one `file` character, so a match always carries them: the empty
+// defaults are the type-level spelling of that invariant, not a runtime
+// path. Hashing runs per reference — the page's references are unique,
+// and re-hashing a small asset is cheaper than a map whose miss no
+// input can reach.
+const collectReferences = async (
   html: string,
   directory: string,
-): Promise<ReadonlyMap<string, string>> => {
-  const files = new Set<string>()
-  for (const match of html.matchAll(REFERENCE)) {
-    const { file = '' } = match.groups ?? {}
-    if (file !== '') {
-      files.add(file)
-    }
-  }
-  return new Map(
-    await Promise.all(
-      [...files].map(async (file): Promise<[string, string]> => [
-        file,
-        await hashOf(path.join(directory, file)),
-      ]),
-    ),
+): Promise<readonly StampedReference[]> =>
+  Promise.all(
+    html
+      .matchAll(REFERENCE)
+      .map(
+        async ({
+          0: { length },
+          groups: { file = '', prefix = '', suffix = '' } = {},
+          index,
+        }): Promise<StampedReference> => {
+          const hash = await hashOf(path.join(directory, file))
+          return {
+            hash,
+            index,
+            length,
+            text: `${prefix}${file}?v=${hash}${suffix}`,
+          }
+        },
+      ),
   )
-}
 
 // Stamp only within a reference context, so the same filename written
 // elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
@@ -112,17 +132,26 @@ const collectHashes = async (
 // arguments cannot carry the named groups safely.
 const stampReferences = (
   html: string,
-  hashes: ReadonlyMap<string, string>,
+  references: readonly StampedReference[],
 ): string => {
   let stamped = ''
   let cursor = 0
-  for (const match of html.matchAll(REFERENCE)) {
-    const { file = '', prefix = '', suffix = '' } = match.groups ?? {}
-    const hash = hashes.get(file) ?? ''
-    stamped += `${html.slice(cursor, match.index)}${prefix}${file}?v=${hash}${suffix}`
-    cursor = match.index + match[0].length
+  for (const { index, length, text } of references) {
+    stamped += html.slice(cursor, index) + text
+    cursor = index + length
   }
   return stamped + html.slice(cursor)
+}
+
+// The page's identity is the join of its UNIQUE stamp values, in
+// DOCUMENT order — exactly the page's own collection (its
+// `webview-freshness` join dedupes stamps through a Set, so a per-FILE
+// dedupe would diverge on two assets with identical bytes): a change to
+// any packaged asset (bundle, stylesheet) moves the identity, so
+// CSS-only or markup-only ships self-heal too.
+const identityOf = (references: readonly StampedReference[]): string | null => {
+  const stamps = [...new Set(references.map(({ hash }) => hash))]
+  return stamps.length > 0 ? stamps.join('.') : null
 }
 
 const stampHtml = async (htmlPath: string): Promise<string | null> => {
@@ -134,17 +163,12 @@ const stampHtml = async (htmlPath: string): Promise<string | null> => {
     // has nothing to stamp.
     return null
   }
-  const hashes = await collectHashes(html, path.dirname(htmlPath))
-  const stamped = stampReferences(html, hashes)
+  const references = await collectReferences(html, path.dirname(htmlPath))
+  const stamped = stampReferences(html, references)
   if (stamped !== html) {
     await writeFile(htmlPath, stamped)
   }
-  // The page's identity is the join of every stamp it carries, in
-  // DOCUMENT order (the match order of `REFERENCE`, which the page's
-  // own collection mirrors): a change to any packaged asset (bundle,
-  // stylesheet) moves the identity, so CSS-only or markup-only ships
-  // self-heal too.
-  return hashes.size > 0 ? hashes.values().toArray().join('.') : null
+  return identityOf(references)
 }
 
 // Emit the live-hash manifest the app serves (`GET /webview-hashes`) —

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,5 @@ sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 # Image CLASS guard, format-agnostic: today's store images are png, but a
 # converted or replaced asset may legitimately arrive as jpg.
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,scripts/**
+sonar.coverage.exclusions=tests/**,**/*.config.*
 sonar.cpd.exclusions=**/*.config.*,settings/index.html

--- a/tests/unit/bundle.test.ts
+++ b/tests/unit/bundle.test.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The bundler is a top-level-await script working against the current
+// directory (the Homey CLI runs it from the packaged app's root), so
+// each test materializes a miniature app in a temp directory, moves
+// there, and imports the script afresh.
+const HASH_LENGTH = 8
+
+const initialDirectory = process.cwd()
+
+const ENTRY_SOURCE = `export const start = (value?: string): string =>
+  value ?? 'booted'
+`
+
+const PAGE_HTML = `<!doctype html>
+<html lang="en">
+    <head>
+        <!-- index.js is mentioned here and must stay unstamped -->
+        <link href="index.css" rel="stylesheet">
+        <script defer src="index.js"></script>
+        <script defer src="index.mjs?v=deadbeef"></script>
+        <script data-origin="settings" defer src="/homey.js"></script>
+    </head>
+    <body></body>
+</html>
+`
+
+const hashOf = (content: string | Buffer): string =>
+  createHash('sha256').update(content).digest('hex').slice(0, HASH_LENGTH)
+
+// Cwd-relative on purpose: every test runs from inside its own temp
+// app, exactly where the Homey CLI runs the script from.
+const seedApp = async (): Promise<void> => {
+  await mkdir('settings', { recursive: true })
+  await writeFile('settings/index.mts', ENTRY_SOURCE)
+}
+
+const seedPackagedPage = async (html: string): Promise<void> => {
+  await mkdir('.homeybuild/settings', { recursive: true })
+  await writeFile('.homeybuild/settings/index.html', html)
+  await writeFile('.homeybuild/settings/index.css', 'body { color: red; }\n')
+}
+
+const runBundler = async (): Promise<void> => {
+  vi.resetModules()
+  await import('../../scripts/bundle.mts')
+}
+
+const packagedFile = async (relativePath: string): Promise<string> =>
+  readFile(path.join('.homeybuild', relativePath), 'utf8')
+
+describe('bundle script', () => {
+  let workDirectory = ''
+
+  beforeEach(async () => {
+    workDirectory = await mkdtemp(path.join(tmpdir(), 'bundle-'))
+    process.chdir(workDirectory)
+    await seedApp()
+  })
+
+  afterEach(async () => {
+    process.chdir(initialDirectory)
+    await rm(workDirectory, { force: true, recursive: true })
+  })
+
+  it('should emit the compat pair into the packaged app', async () => {
+    await runBundler()
+
+    const iife = await packagedFile('settings/index.js')
+    const twin = await packagedFile('settings/index.mjs')
+
+    expect(iife).toContain('var HeatzyWebview')
+    expect(iife).not.toContain('export')
+    // The twin is a SECOND IIFE, not ESM: the cached-HTML era loaded it
+    // as a classic `defer` script, so its footer self-wires the global
+    // the SDK calls and an `export` would choke the page.
+    expect(twin).toContain('var HeatzyWebview')
+    expect(twin).not.toContain('export')
+    expect(twin).toContain('globalThis.onHomeyReady')
+    expect(twin).toContain('HeatzyWebview.start(homey)')
+    // es2020 target: nullish coalescing ships as-is, unlowered
+    expect(iife).toContain('??')
+  })
+
+  it('should stamp references only, and emit the manifest', async () => {
+    await seedPackagedPage(PAGE_HTML)
+
+    await runBundler()
+
+    const stamped = await packagedFile('settings/index.html')
+    const jsHash = hashOf(await packagedFile('settings/index.js'))
+    const cssHash = hashOf(await packagedFile('settings/index.css'))
+    const mjsHash = hashOf(await packagedFile('settings/index.mjs'))
+
+    expect(stamped).toContain(`href="index.css?v=${cssHash}"`)
+    expect(stamped).toContain(`src="index.js?v=${jsHash}"`)
+    // The stale stamp is replaced, never doubled
+    expect(stamped).toContain(`src="index.mjs?v=${mjsHash}"`)
+    expect(stamped).not.toContain('deadbeef')
+    // Outside a reference context nothing moves
+    expect(stamped).toContain(
+      '<!-- index.js is mentioned here and must stay unstamped -->',
+    )
+    expect(stamped).toContain('src="/homey.js"')
+
+    const manifest: unknown = JSON.parse(
+      await packagedFile('webview-hashes.json'),
+    )
+
+    // Document order: stylesheet first, then the two bundles
+    expect(manifest).toStrictEqual({
+      settings: [cssHash, jsHash, mjsHash].join('.'),
+    })
+  })
+
+  it('should rewrite nothing when the stamps are already fresh', async () => {
+    await seedPackagedPage(PAGE_HTML)
+
+    await runBundler()
+
+    const once = await packagedFile('settings/index.html')
+
+    await runBundler()
+
+    await expect(packagedFile('settings/index.html')).resolves.toBe(once)
+  })
+
+  it('should move the stamps when an asset changes', async () => {
+    await seedPackagedPage(PAGE_HTML)
+
+    await runBundler()
+
+    const before = await packagedFile('settings/index.html')
+    await writeFile('.homeybuild/settings/index.css', 'body { color: blue; }\n')
+
+    await runBundler()
+
+    await expect(packagedFile('settings/index.html')).resolves.not.toBe(before)
+  })
+
+  it('should join identical stamps once, as the page itself does', async () => {
+    await seedPackagedPage(
+      '<html><head><link href="a.css" rel="stylesheet"><link href="b.css" rel="stylesheet"></head></html>',
+    )
+    const twinBytes = 'body { margin: 0; }\n'
+    await writeFile('.homeybuild/settings/a.css', twinBytes)
+    await writeFile('.homeybuild/settings/b.css', twinBytes)
+
+    await runBundler()
+
+    const manifest: unknown = JSON.parse(
+      await packagedFile('webview-hashes.json'),
+    )
+
+    // The page joins UNIQUE stamp values — the manifest must agree, or
+    // twin-byte assets would loop the freshness handshake
+    expect(manifest).toStrictEqual({ settings: hashOf(twinBytes) })
+  })
+
+  it('should stamp nothing in a standalone suite run', async () => {
+    await runBundler()
+
+    await expect(packagedFile('webview-hashes.json')).rejects.toThrow('ENOENT')
+  })
+
+  it('should skip the manifest when a page carries no local reference', async () => {
+    await seedPackagedPage(
+      '<html><head><script src="/homey.js"></script></head></html>',
+    )
+
+    await runBundler()
+
+    await expect(packagedFile('webview-hashes.json')).rejects.toThrow('ENOENT')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ const config: ViteUserConfig = defineConfig({
   plugins: [swcPlugin],
   test: {
     coverage: {
-      exclude: ['.homeybuild/**', 'scripts/**/*.mts'],
+      exclude: ['.homeybuild/**'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
`vitest.config.ts` and `sonar-project.properties` both swept `scripts/**` out of coverage — the last unmotivated directory exclusion of the family (com.melcloud.extension already covers its bundler; com.melcloud names and quantifies each of its exclusions). Sweeps hide code rather than justify it, so this covers the bundler for real instead.

Covering it surfaced a genuine defect. `stampHtml` built its identity from a map keyed by FILE and joined `hashes.values()`, while the page's own identity (`webview-freshness`, in homey-kit) dedupes stamps through a `Set` and joins UNIQUE values. Two packaged assets with identical bytes therefore served `h.h` where the page computed `h` — a mismatch that survives its one refetch, so every boot ended in a `POST /boot-error`. The shared logic now matches the reviewed sibling form (`StampedReference` / `collectReferences` / `identityOf`), which documents exactly this trap.

The esbuild options also gained `absWorkingDir`: esbuild's service process outlives the module and keeps its own working directory, so relative entry points must be anchored to the app root explicitly — the same pin the extension already carries.

The compat divergence stays untouched and commented: this app's `index.mjs` twin is a SECOND IIFE with a self-wiring footer, never ESM, because its cached-HTML era loaded it as a classic `defer` script.

## Coverage

`scripts/bundle.mts` is now in scope and the thresholds hold at 100 % on all four metrics — 556 statements, 217 branches, 186 functions, 545 lines, no `v8 ignore` introduced (the family still carries zero).

## Tests

Seven cases on a temp filesystem, each materializing a miniature app and importing the script afresh: the IIFE/ESM compat pair (twin asserted as an IIFE carrying its `onHomeyReady` footer), stamping limited to reference contexts, a stale stamp replaced rather than doubled, idempotence, the manifest in document order, the twin-bytes join, and the two standalone-run paths that must emit no manifest.

The twin-bytes case was verified load-bearing: reverting the dedupe fails it with `expected { settings: 'eac0e790.eac0e790' } to strictly equal { settings: 'eac0e790' }`.

## Gates

`format`, `lint`, `typecheck`, `test:coverage`, `build` and `homey:validate` all green locally; validation touched no file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3