### PR TITLE
docs: use the platform's straight apostrophe in the French strings

### DIFF
--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "errors": { "deviceNotFound": "Appareil introuvable." },
   "notifications": {
-    "sessionExpired": "Votre session Heatzy a expiré : reconnectez-vous depuis les réglages de l’application.",
+    "sessionExpired": "Votre session Heatzy a expiré : reconnectez-vous depuis les réglages de l'application.",
     "sessionRestored": "Votre session Heatzy est de nouveau active."
   },
   "settings": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3,7 +3,7 @@
     "deviceNotFound": "Appareil introuvable."
   },
   "notifications": {
-    "sessionExpired": "Votre session Heatzy a expiré : reconnectez-vous depuis les réglages de l’application.",
+    "sessionExpired": "Votre session Heatzy a expiré : reconnectez-vous depuis les réglages de l'application.",
     "sessionRestored": "Votre session Heatzy est de nouveau active."
   },
   "settings": {


### PR DESCRIPTION
Audit of every localized string in the three apps against homey-lib's corpus (936 French strings across capability titles, descriptions and flow hints).

homey-lib writes the apostrophe straight — 274 occurrences against 2 typographic. This app matched it in 7 strings and diverged in one, which also made the app internally inconsistent with itself: `notifications.sessionExpired`.

Everything else measured as already aligned: the device term (`appareil`, as homey-lib), and no quotation, percent or dash conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3