### PR TITLE
build: adopt configs 1.8.0 and hand the HTML to Prettier

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
     with:
       check-node-version: '22'
-      # The fleet's Node major — measured 22.20/22.23 on-device
-      # (2026-08); the coverage/Sonar leg tracks it, not lts/*.
-      coverage-node-version: '22'
+      # The fleet's floor, measured on-device (2026-08): 22.20 on a Pro
+      # 2019, 22.23 on a Pro 2023. `22` resolves to the head of the line
+      # and drifts off that floor, so the coverage/Sonar leg names the
+      # minor itself. The quotes are load-bearing: unquoted, `22.20` is
+      # JSON for the number 22.2.
+      coverage-node-version: '22.20'
+      node-versions: '["22", "22.20", "latest", "lts/*"]'
 name: CI
 on:
   merge_group: {}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
     with:
       repo-guidance: 'A bug in @olivierzal/heatzy-api is fixed there, never worked around in this app. When the bump is @olivierzal/configs, realign every `uses: OlivierZal/configs/...` ref in .github/workflows to the tag matching the new npm pin, comment included — one version covers both channels. Stop and leave the pull request failing for human review when that release changes lint policy: adopting it needs per-repository judgement no automated fix can make.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: Dependabot
 on: pull_request
 permissions: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: zizmor
 on:
   merge_group: {}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-*.html
 # Written by the Homey CLI on every preprocess, without a trailing
 # newline, and committed in that exact form: Prettier would add the
 # newline back and put the tree out of step with the next CLI run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.6.0",
+        "@olivierzal/configs": "1.8.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.6.0/474d9fe4cb9ff56cee39a9e62660cb26f9fd71ed",
-      "integrity": "sha512-l+JqAg4eXdPjQFxRKqK1jZg86ki67MAVqJq6wesx5ZrKULic+NDMG0UNT+zf3dC0He+6Jh/rpvZPdxYWlpO6nw==",
+      "version": "1.8.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.8.0/d708e6a3522b167c2f6151a8cd95113813a87ffb",
+      "integrity": "sha512-GfpGEX1SouX/o4gzDvM4oYmDNObCFKgLCPdM0f/Qa/LqZ7Ra0TQzrthM3NDsey6ru9R9BryVlZ+qgJTwzG6KmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.6.0",
+    "@olivierzal/configs": "1.8.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,99 +1,121 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <title>Heatzy Settings</title>
-        <script>
-            // The page bundle loads as a classic defer script, not an ES
-            // module: a static module script stalls the whole boot on a
-            // cold webview open (a stalled module fetch also blocks
-            // onHomeyReady — proven on-device in com.melcloud), while
-            // classic scripts, like the stylesheet, load cold. The poll
-            // keeps the boot bounded: it hands the instance to the
-            // bundle's start once it is up, or reports why and ends the
-            // overlay if it never arrives.
-            function onHomeyReady(homey) {
-                const deadline = Date.now() + 10000
-                const waitForBundle = () => {
-                    if (globalThis.HeatzyWebview) {
-                        globalThis.HeatzyWebview.start(homey)
-                    } else if (Date.now() > deadline) {
-                        // Boot beacon: the bundle never booted — report WHY
-                        // before degrading. A 200 probe with no global means
-                        // the script fetched but failed to parse/run (old
-                        // engine); a probe error means the fetch itself
-                        // fails on this device.
-                        const script = document.querySelector('script[src*="index.js"]')
-                        const report = (probe) => {
-                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent }, () => {})
-                            homey.ready()
-                            homey.alert(homey.__('settings.loadFailed')).catch(() => {})
-                        }
-                        fetch(script ? script.src : 'index.js')
-                            .then((response) => { report('fetch ' + String(response.status)) })
-                            .catch((error) => { report('fetch failed: ' + String(error)) })
-                    } else {
-                        setTimeout(waitForBundle, 50)
-                    }
-                }
-                waitForBundle()
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Heatzy Settings</title>
+    <script>
+      // The page bundle loads as a classic defer script, not an ES
+      // module: a static module script stalls the whole boot on a
+      // cold webview open (a stalled module fetch also blocks
+      // onHomeyReady — proven on-device in com.melcloud), while
+      // classic scripts, like the stylesheet, load cold. The poll
+      // keeps the boot bounded: it hands the instance to the
+      // bundle's start once it is up, or reports why and ends the
+      // overlay if it never arrives.
+      function onHomeyReady(homey) {
+        const deadline = Date.now() + 10000
+        const waitForBundle = () => {
+          if (globalThis.HeatzyWebview) {
+            globalThis.HeatzyWebview.start(homey)
+          } else if (Date.now() > deadline) {
+            // Boot beacon: the bundle never booted — report WHY
+            // before degrading. A 200 probe with no global means
+            // the script fetched but failed to parse/run (old
+            // engine); a probe error means the fetch itself
+            // fails on this device.
+            const script = document.querySelector('script[src*="index.js"]')
+            const report = (probe) => {
+              homey.api(
+                'POST',
+                '/boot-error',
+                {
+                  message: 'The settings bundle did not boot within 10s',
+                  name: 'BootTimeout',
+                  probe,
+                  userAgent: navigator.userAgent,
+                },
+                () => {},
+              )
+              homey.ready()
+              homey.alert(homey.__('settings.loadFailed')).catch(() => {})
             }
-        </script>
-        <link href="index.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <script data-origin="settings" defer src="/homey.js"></script>
-        <meta content="Heatzy settings" name="description">
-    </head>
-    <body>
-        <header class="homey-header">
-            <h1
-                class="homey-title"
-                data-i18n="settings.title"
-            >Heatzy settings</h1>
-        </header>
-        <!-- Collapsible: folded when signed in (the credentials are
+            fetch(script ? script.src : 'index.js')
+              .then((response) => {
+                report('fetch ' + String(response.status))
+              })
+              .catch((error) => {
+                report('fetch failed: ' + String(error))
+              })
+          } else {
+            setTimeout(waitForBundle, 50)
+          }
+        }
+        waitForBundle()
+      }
+    </script>
+    <link href="index.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <script data-origin="settings" defer src="/homey.js"></script>
+    <meta content="Heatzy settings" name="description" />
+  </head>
+  <body>
+    <header class="homey-header">
+      <h1 class="homey-title" data-i18n="settings.title">Heatzy settings</h1>
+    </header>
+    <!-- Collapsible: folded when signed in (the credentials are
             settled), expanded while signed out. -->
-        <details id="authentication" class="homey-form-fieldset">
-            <summary class="homey-form-legend" data-i18n="settings.authenticate.legend">Credentials</summary>
-            <fieldset id="login" class="busy-scope"></fieldset>
-            <div class="homey-form-group container">
-                <button
-                    id="reset_credentials"
-                    type="button"
-                    class="homey-button-primary-full"
-                    data-i18n="settings.authenticate.reset"
-                >Reset</button>
-                <button
-                    id="authenticate"
-                    type="button"
-                    class="homey-button-primary-full"
-                    data-i18n="settings.authenticate.button"
-                >Log in</button>
-            </div>
-        </details>
-        <!-- Shown once authenticated — hidden by default to prevent a flash. -->
-        <fieldset
-            id="devices"
-            class="homey-form-fieldset"
-            hidden
+    <details id="authentication" class="homey-form-fieldset">
+      <summary
+        class="homey-form-legend"
+        data-i18n="settings.authenticate.legend"
+      >
+        Credentials
+      </summary>
+      <fieldset id="login" class="busy-scope"></fieldset>
+      <div class="homey-form-group container">
+        <button
+          id="reset_credentials"
+          type="button"
+          class="homey-button-primary-full"
+          data-i18n="settings.authenticate.reset"
         >
-            <legend class="homey-form-legend" data-i18n="settings.devices.legend">All device settings</legend>
-            <div id="settings_common"></div>
-            <div class="homey-form-group container">
-                <button
-                    id="refresh_settings_common"
-                    type="button"
-                    class="homey-button-secondary-shadow"
-                    data-i18n="settings.refresh"
-                >Refresh</button>
-                <button
-                    id="apply_settings_common"
-                    type="button"
-                    class="homey-button-danger-shadow"
-                    data-i18n="settings.update"
-                >Update</button>
-            </div>
-        </fieldset>
-    </body>
+          Reset
+        </button>
+        <button
+          id="authenticate"
+          type="button"
+          class="homey-button-primary-full"
+          data-i18n="settings.authenticate.button"
+        >
+          Log in
+        </button>
+      </div>
+    </details>
+    <!-- Shown once authenticated — hidden by default to prevent a flash. -->
+    <fieldset id="devices" class="homey-form-fieldset" hidden>
+      <legend class="homey-form-legend" data-i18n="settings.devices.legend">
+        All device settings
+      </legend>
+      <div id="settings_common"></div>
+      <div class="homey-form-group container">
+        <button
+          id="refresh_settings_common"
+          type="button"
+          class="homey-button-secondary-shadow"
+          data-i18n="settings.refresh"
+        >
+          Refresh
+        </button>
+        <button
+          id="apply_settings_common"
+          type="button"
+          class="homey-button-danger-shadow"
+          data-i18n="settings.update"
+        >
+          Update
+        </button>
+      </div>
+    </fieldset>
+  </body>
 </html>

--- a/tests/unit/bundle.test.ts
+++ b/tests/unit/bundle.test.ts
@@ -17,16 +17,25 @@ const ENTRY_SOURCE = `export const start = (value?: string): string =>
   value ?? 'booted'
 `
 
+// Prettier owns the page's shape, so the fixture carries the two forms
+// it emits: attributes inline, and — once a tag outgrows the print
+// width — one per line. A reference pattern scoped to a tag or to a
+// single line would still stamp the inline form and silently miss the
+// exploded one.
 const PAGE_HTML = `<!doctype html>
 <html lang="en">
-    <head>
-        <!-- index.js is mentioned here and must stay unstamped -->
-        <link href="index.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <script defer src="index.mjs?v=deadbeef"></script>
-        <script data-origin="settings" defer src="/homey.js"></script>
-    </head>
-    <body></body>
+  <head>
+    <!-- index.js is mentioned here and must stay unstamped -->
+    <link href="index.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <script
+      data-testid="a-tag-past-the-print-width-that-prettier-explodes"
+      defer
+      src="index.mjs?v=deadbeef"
+    ></script>
+    <script data-origin="settings" defer src="/homey.js"></script>
+  </head>
+  <body></body>
 </html>
 `
 

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -43,6 +43,12 @@ interface HomeyOptions {
   readonly translations?: Readonly<Record<string, string>>
 }
 
+// The wording an element shows, whitespace-collapsed the way HTML
+// renders it: the markup's own spacing is Prettier's to choose, so only
+// the words are a contract the page owes.
+const shownText = (selector: string): string | undefined =>
+  document.querySelector(selector)?.textContent.replaceAll(/\s+/gv, ' ').trim()
+
 const driverSettingsFixture = (): Partial<Record<string, DriverSetting[]>> => ({
   login: [
     {
@@ -313,16 +319,11 @@ describe('settings page', () => {
         },
       })
 
-      expect(document.querySelector('.homey-title')?.textContent).toBe(
-        'Réglages Heatzy',
+      expect(shownText('.homey-title')).toBe('Réglages Heatzy')
+      expect(shownText('[data-i18n="settings.authenticate.legend"]')).toBe(
+        'Credentials',
       )
-      expect(
-        document.querySelector('[data-i18n="settings.authenticate.legend"]')
-          ?.textContent,
-      ).toBe('Credentials')
-      expect(
-        document.querySelector('[data-i18n="settings.update"]')?.textContent,
-      ).toBe('Update')
+      expect(shownText('[data-i18n="settings.update"]')).toBe('Update')
     })
 
     it('should alert after the overlay when the build fails', async () => {


### PR DESCRIPTION
Adopts `@olivierzal/configs@1.8.0` and completes the HTML formatting shift it unblocks.

## Why the two travel together

The 1.8.0 preset stops enforcing what Prettier decides. Four `html/` rules actively **rejected** Prettier's output (`indent`, `attrs-newline`, `no-extra-spacing-tags`, `require-closing-tags`), so removing `*.html` from `.prettierignore` was only safe once they were gone. `html/sort-attrs`, `head-order` and `no-whitespace-only-children` stay on — Prettier does not do them.

## The coverage guard

1.8.0's reusable CI fails the `check` job when `coverage-node-version` names a version the matrix never carries. Until now a typo selected no leg, so `npm test -- --coverage` and the Sonar upload silently stopped running behind green legs — and neither `Test (Node latest)` nor SonarCloud is a required context anywhere, so nothing downstream caught it.

The matrix now names the fleet's real floor. Measured on-device (2026-08): **22.20** on a Pro 2019, **22.23** on a Pro 2023 — while `22` and `lts/*` both resolve to the head of their line, so no leg exercised 22.20. Keeping `"22"` alongside `"22.20"` leaves `ci / Test (Node 22)` reporting under its current name, so **no ruleset changes**.

Both guards verified from this repo, including their refusals:

```
checked 14 pinned reference(s) across 12 file(s)
coverage runs on the Node 22.20 leg of ["22", "22.20", "latest", "lts/*"]
error: coverage-node-version `22.2O` names no leg of node-versions [...]
error: node-versions entries must be quoted: [22.2] installs and is compared as "22.2"
```

## The `?v=` stamping survives — proven, not assumed

`scripts/bundle.mts` finds local assets by regex in attribute context, and Prettier rewrites attributes. Verified through the real packaging path (`homey app validate` → CLI copy → `npm run build`):

```
<link href="index.css?v=2aa1e054" rel="stylesheet" />
<script defer src="index.js?v=0a297cf3"></script>
<script data-origin="settings" defer src="/homey.js"></script>
{"settings":"2aa1e054.0a297cf3"}
```

`/homey.js` stays unstamped, and the manifest identity equals the document-order join of the page's unique stamps — the freshness handshake agrees on both sides.

## What the reformat actually changed

Prettier explodes long tags and puts element text on its own line, which pads `textContent` with whitespace. Nothing reads it at runtime (`translatePage` **writes** it), but two assertions compared the authored fallback byte for byte and failed. They now compare the wording HTML renders, which is the contract the page owes; the markup's spacing is Prettier's.

The bundler fixture gains Prettier's exploded-tag form. That has teeth: scoping the reference pattern to a single line fails two of its tests.

## Checks

`format`, `lint`, `typecheck` and `homey:validate` all exit 0; 200 tests pass at 100 % statements/branches/functions/lines. `homey:validate` rewrote nothing.

The pre-existing `nanoid` advisory is untouched by this branch — it is already on `main`.