### PR TITLE
build(deps): raise nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6184,9 +6184,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`npm audit` reported `nanoid` <3.3.17 (GHSA-2v37-7h3g-55p8, high) on `main`.

**It does not reach the device.** The chain is `vitest` → `vite` → `postcss` → `nanoid`, all dev, and the lockfile marks it `"dev": true`. Measured:

- `npm audit --omit=dev` → **0 vulnerabilities**
- production tree → **9 packages, 10 MB** (`@olivierzal/heatzy-api`, `@olivierzal/homey-kit`, `source-map-support` and their transitives)

That measurement matters here for a specific reason: a past regression shipped 67 packages / 73 MB to the Homey — including this very `nanoid` — because optional peers of a *production* dependency fell into `--omit=dev`. This is not that. `@olivierzal/configs` is a devDependency, and `@olivierzal/homey-kit` still resolves with zero dependencies.

`postcss` already accepts `^3.3.16`, so the fix is a lockfile refresh: 3.3.16 → 3.3.18, three lines, no manifest change.

Local: format, lint, typecheck, 200 tests, 100 % on all four axes, `homey:validate` at publish level with no rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3