### PR TITLE
docs: add the contributing guide the doctrine already assumed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing
+
+Thanks for considering a contribution. This document describes the local
+workflow expected before opening a pull request.
+
+## Prerequisites
+
+- Node.js matching `engines.node` in [`package.json`](package.json) —
+  currently `^22.22.2 || >=24.15.0`, the **development** floor derived
+  from the installed tree, not the floor the device runs
+- npm 10+
+- A GitHub personal access token with the `read:packages` scope, exported
+  as `NODE_AUTH_TOKEN` — [`.npmrc`](.npmrc) reads that variable to fetch
+  the `@olivierzal` packages from GitHub Packages
+- A Homey Pro to install onto, for anything touching the settings page
+
+## Setup
+
+```sh title="setup"
+git clone https://github.com/OlivierZal/com.heatzy.git
+cd com.heatzy
+npm ci
+```
+
+## Local checks
+
+Run the full suite before pushing — CI runs all of it, and each step has
+caught failures the others miss:
+
+```sh title="checks"
+npm run format          # prettier --check (npm run format:fix to write)
+npm run lint            # ESLint, including CSS and HTML
+npm run typecheck       # native tsc --noEmit
+npm test                # vitest run
+npm run test:coverage   # must remain at 100% on all four axes
+npm run build           # esbuild bundle + tsc emit, both into .homeybuild
+npm run homey:validate  # Homey validation at publish level
+```
+
+`npm run homey:validate` **may rewrite files** — `app.json` and
+`locales/*.json` are generated. If it touches anything, amend before
+pushing.
+
+## Generated files are not sources
+
+[`.homeycompose/`](.homeycompose) is the source for `app.json` and
+`locales/*.json`. The Homey CLI regenerates those outputs on every
+preprocess and writes them **without a trailing newline**. Commit the
+CLI-generated form verbatim; never edit a generated file directly, and
+never "fix" the missing newline.
+
+## Two runtimes, two floors
+
+Node-side code follows `engines.node` and may use modern APIs freely.
+
+Webview code — [`settings/`](settings) — runs on **phone browser
+engines**, not on the Homey. Those stall at **es2023**, a separate and
+lower ceiling the lint enforces on exactly that path. esbuild lowers
+syntax but never polyfills APIs, so a too-recent API passes both the lint
+and the compile and fails only on a user's phone. Raising one floor never
+raises the other; conflating them has already caused a production
+incident in a sibling app.
+
+The floor the device runs is a third, distinct declaration:
+`compatibility` in [`.homeycompose/app.json`](.homeycompose/app.json).
+
+## On-device testing
+
+```sh title="device"
+npm run homey:start     # homey app run --remote
+npm run homey:install
+```
+
+Any markup change that multiplies `homey-form-*` elements needs a cold
+open on a real device: Homey injects a stylesheet that is not in this
+repo, and a headless probe cannot see it.
+
+## Coverage
+
+Branches, functions, lines and statements are enforced at **100%** in
+[`vitest.config.ts`](vitest.config.ts). New code arrives with the tests
+that keep those thresholds green. A test that cannot fail proves nothing
+— verify by mutation that a new test breaks when the behaviour it pins
+breaks.
+
+## Commits & pull requests
+
+- **The pull request title is the commit that lands.** Squash merging is
+  the only merge method and it takes the PR title, so the title must
+  follow [Conventional Commits](https://www.conventionalcommits.org).
+  A required check enforces it.
+- Companion docs are part of a change's definition of done: a pull
+  request that changes behaviour, API surface, requirements or process
+  updates [`README.md`](README.md), this file,
+  [`SECURITY.md`](SECURITY.md) and [`CLAUDE.md`](CLAUDE.md) in the same
+  pull request — never in a later sweep.
+- All required checks must pass, and every review thread must end
+  resolved: with a change when the point holds, or with a reasoned reply
+  when it does not.
+
+## Releases
+
+Store releases are cut through a pull request: write the user-facing
+entry into `.homeychangelog.json` under the new version key — this app
+ships **English and French** — bump `version` in
+`.homeycompose/app.json`, align `package.json` with
+`npm version X.Y.Z --no-git-tag-version`, then run
+`npm run homey:validate` to regenerate `app.json`. Once merged, tag
+`vX.Y.Z` and publish a GitHub release — that is what pushes the app to
+the store.
+
+A changelog entry is **deliberately non-exhaustive**: it addresses the
+user, so tooling, refactors and test work stay out of it. When a release
+would carry nothing a user can observe, the honest move is not to cut one
+— publishing burns a version number and a store review for nothing. A
+rejected version number cannot be resubmitted; bump the patch instead.


### PR DESCRIPTION
`CLAUDE.md` names `CONTRIBUTING.md` among the companion files a behaviour change must update in the same pull request — while the file never existed. Four of the seven family repositories had one; this closes one of the three gaps.

Written for what a Homey app is rather than copied from the libraries, whose guides speak of `publint`, typedoc output and a registry token that have no currency here. It records the pieces a contributor cannot infer: `.homeycompose/` is the source and `app.json` is generated without a trailing newline, the **two runtime floors** (node-side `engines` versus the es2023 ceiling the lint holds over `settings/`) plus the third that `compatibility` declares for the device, the cold-open requirement for markup that multiplies `homey-form-*` elements, and a release flow whose changelog is deliberately non-exhaustive — including that not cutting a release is the honest move when nothing is user-observable.

This app ships its changelog in English and French, not the thirteen locales of its sibling; the guide says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3