### PR TITLE
docs: record the commented-reference edges of the stamping pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,13 @@ caught real failures that the others miss:
   across app versions) refetch an asset exactly when its bytes change.
   The committed source HTML carries NO stamps — never hand-add a `?v=`
   there, and nothing needs re-committing when a webview source changes.
-  Stamps exist only in the packaged app, and only within
-  attribute/import reference contexts, never comments.
+  Stamps exist only in the packaged app, within attribute/import
+  reference contexts (`href="`/`src="`) — matched WHEREVER they appear,
+  HTML comments included: a commented reference to a missing file fails
+  the packaging pass, and one to a real file would be stamped by the
+  builder yet invisible to the page-side DOM query, splitting the two
+  identities into an endless refetch handshake. Delete a dead
+  reference, never comment it out.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (see locales below), re-stage if it does.
 - `npm run homey:start` — `homey app run --remote` for on-device testing.

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -126,10 +126,16 @@ const collectReferences = async (
       ),
   )
 
-// Stamp only within a reference context, so the same filename written
-// elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
-// rather than through a `replaceAll` callback, whose loosely typed rest
-// arguments cannot carry the named groups safely.
+// Stamp only within a reference context (`href="`/`src="`), so a bare
+// filename written elsewhere (e.g. prose in a comment) is never
+// rewritten. A FULL reference inside an HTML comment still matches:
+// pointing at a missing file it fails the packaging pass (ENOENT);
+// pointing at a real file it earns a stamp the page-side DOM query
+// never sees, splitting the builder identity from the page identity —
+// one refetch, then a boot-error on every open. No page carries a
+// commented reference today; delete, never comment out. Rebuilt
+// cursor-wise rather than through a `replaceAll` callback, whose
+// loosely typed rest arguments cannot carry the named groups safely.
 const stampReferences = (
   html: string,
   references: readonly StampedReference[],


### PR DESCRIPTION
The doctrine and the script docstring claimed a comment is never rewritten — true only for a bare filename in prose. A full `href="`/`src="` reference inside an HTML comment still matches: pointing at a missing file it fails the packaging pass (ENOENT); pointing at a real file it earns a stamp the page-side DOM query never sees, splitting the builder identity from the page identity — one refetch, then a boot-error on every open. No page carries a commented reference today; the rule is to delete a dead reference, never comment it out. Wording aligned on com.melcloud.extension's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3