### PR TITLE
docs: derive the webview floor from the app's iOS minimum

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,15 +208,23 @@ coverage.
   com.melcloud (2026-08-06): tsc checks the import CLOSURE, which
   crosses into node-side code — the same shape exists here
   (`settings/` imports shared `lib/` and `types/` modules).
+- That floor is DERIVED, not preventive: the Homey mobile app requires
+  iOS 16.4 or later (App Store, read 2026-08-11) and a Homey app only
+  ever gets the system WebKit, so the worst legitimate engine is iOS
+  16.4's — es2023-complete, short of every es2024 gain (`Object.groupBy`
+  and `Promise.withResolvers` need Safari 17.4, the `v` flag 17). es2024
+  becomes derivable when that App Store minimum reaches 17.4; Android
+  never binds the floor, its System WebView being evergreen.
 - TWO floors coexist, on UNRELATED engines — never let one move the
-  other. The **webview** floor is es2023 and is set by the phone's
-  WebKit, which no Homey firmware can rejuvenate: it stays enforced by
-  the scoped lint block above, and the danger there is APIs, because
-  esbuild lowers syntax but NEVER polyfills (`Object.groupBy`, iterator
-  helpers…; the regex `v` flag is the mixed case — syntax esbuild does
-  not lower, hence its place in the same block). The **node-side**
-  floor is the Homey's own Node, and it is held by the manifest's
-  `compatibility` declaration, not by a check.
+  other. The **webview** floor is the derived one above, held by the
+  scoped lint block, and the danger there is APIs, because esbuild
+  lowers syntax but NEVER polyfills (`Object.groupBy`, iterator
+  helpers…). The `v` flag is the mixed case: under a sub-es2024 target
+  esbuild defers the literal to a `new RegExp` call, so an escapee
+  throws at RUNTIME, not at parse, inside the feature that runs it —
+  narrower blast radius, same ban. The **node-side** floor is the
+  Homey's own Node, and it is held by the manifest's `compatibility`
+  declaration, not by a check.
 - A floor is declared from WHERE THE CODE RUNS, never from what a
   dependency happens to require. `compatibility: ">=12.9.0"` is
   Athom's own documented Node 22 boundary ("as of Homey v12.9.0, all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,12 @@ never "fix" the missing newline.
 Node-side code follows `engines.node` and may use modern APIs freely.
 
 Webview code — [`settings/`](settings) — runs on **phone browser
-engines**, not on the Homey. Those stall at **es2023**, a separate and
-lower ceiling the lint enforces on exactly that path. esbuild lowers
-syntax but never polyfills APIs, so a too-recent API passes both the lint
-and the compile and fails only on a user's phone. Raising one floor never
+engines**, not on the Homey. Its ceiling is **es2023**, derived from the
+Homey mobile app's own iOS 16.4 minimum (App Store, 2026-08-11): an app
+only ever gets the system WebKit, and iOS 16.4's has none of es2024. The
+lint enforces that ceiling on exactly that path. esbuild lowers syntax
+but never polyfills APIs, so a too-recent API passes both the lint and
+the compile and fails only on a user's phone. Raising one floor never
 raises the other; conflating them has already caused a production
 incident in a sibling app.
 

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -33,8 +33,9 @@ import {
 import type { DeviceSettings, Settings } from '../types/device-settings.mts'
 
 // Runtime floor: esbuild lowers syntax to es2020, but runtime APIs must
-// stay ≤ es2023 — no iterator helpers, no Object.groupBy (old iOS
-// engines are real).
+// stay ≤ es2023 — no iterator helpers, no Object.groupBy: the Homey
+// mobile app requires iOS 16.4 or later (App Store, 2026-08-11) and
+// this page only ever gets that system WebKit.
 
 const commonElementTypes = new Set(['checkbox', 'dropdown'])
 


### PR DESCRIPTION
The webview floor was written as a precaution — "old iOS engines are real" — with no measurement behind it. It has one: the Homey mobile app declares **Requires iOS 16.4 or later** on the App Store (read 2026-08-11), and a Homey app only ever gets the system WebKit. The worst legitimate engine is therefore iOS 16.4's, which is es2023-complete and short of every es2024 gain (`Object.groupBy` and `Promise.withResolvers` need Safari 17.4, the `v` flag 17). es2023 is exactly right, by derivation. The re-derivation trigger is written down too: es2024 becomes derivable when that App Store minimum reaches 17.4. Android never binds the floor, its System WebView being evergreen.

One severity claim is corrected. Under a sub-es2024 esbuild target a `v` regex literal from a webview source ships as a `new RegExp` call, so an escapee throws at **runtime**, inside the feature that runs it — not at parse, and not the whole page. Narrower blast radius, same ban: the API fails either way, and the scoped lint block is unchanged.

Doctrine only — `CLAUDE.md`, `CONTRIBUTING.md` and the floor comment in `settings/index.mts`. No rule, config or behavior moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)